### PR TITLE
fix(tools): isolate result cache failures

### DIFF
--- a/packages/mcp/src/catalog.ts
+++ b/packages/mcp/src/catalog.ts
@@ -240,14 +240,29 @@ export interface MCPSchemaCacheEntry {
   cachedAt: string;
 }
 
+export interface MCPSchemaCacheOptions {
+  maxEntries?: number;
+  now?: () => string;
+}
+
 export class MCPSchemaCache {
   private readonly entries = new Map<string, MCPSchemaCacheEntry>();
+  private readonly maxEntries: number;
+  private readonly now: () => string;
+
+  constructor(options: MCPSchemaCacheOptions = {}) {
+    this.maxEntries = Math.max(1, options.maxEntries ?? 10_000);
+    this.now = options.now ?? (() => new Date().toISOString());
+  }
 
   get(ref: MCPCapabilityRef & { protocolVersion?: string }): MCPSchemaCacheEntry | null {
     if (!ref.capabilityHash) return null;
-    return clone(
-      this.entries.get(schemaCacheKey({ ...ref, capabilityHash: ref.capabilityHash })) ?? null
-    );
+    const key = schemaCacheKey({ ...ref, capabilityHash: ref.capabilityHash });
+    const entry = this.entries.get(key);
+    if (!entry) return null;
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    return clone(entry);
   }
 
   set(record: MCPCapabilityRecord): MCPSchemaCacheEntry {
@@ -258,9 +273,15 @@ export class MCPSchemaCache {
       capabilityHash: record.capabilityHash,
       protocolVersion: record.protocolVersion,
       schema: record.normalizedToolSpec?.inputSchema,
-      cachedAt: new Date().toISOString(),
+      cachedAt: this.now(),
     };
+    this.entries.delete(entry.key);
     this.entries.set(entry.key, entry);
+    while (this.entries.size > this.maxEntries) {
+      const oldestKey = this.entries.keys().next().value as string | undefined;
+      if (!oldestKey) break;
+      this.entries.delete(oldestKey);
+    }
     return clone(entry);
   }
 
@@ -273,6 +294,10 @@ export class MCPSchemaCache {
       }
     }
     return removed;
+  }
+
+  size(): number {
+    return this.entries.size;
   }
 }
 

--- a/packages/mcp/src/mcp.test.ts
+++ b/packages/mcp/src/mcp.test.ts
@@ -16,6 +16,7 @@ import {
   createClassicMCPMockGateway,
   governedMCPIntegrationDefinition,
   governedMCPIntegrationJsonSchemas,
+  mcpCapabilityRecordExample,
   mcpCapabilityRecordDefinition,
   mcpConnectionRecordDefinition,
   mcpIntegrationSpecDefinition,
@@ -30,6 +31,39 @@ import {
 } from './index';
 
 describe('@hypha/mcp normalization', () => {
+  it('bounds the MCP schema cache with least-recently-used eviction', () => {
+    const schemaCache = new MCPSchemaCache({
+      maxEntries: 2,
+      now: () => '2026-07-21T00:00:00.000Z',
+    });
+    for (let index = 0; index < 3; index += 1) {
+      schemaCache.set({
+        ...mcpCapabilityRecordExample,
+        id: `record-${index}`,
+        remoteName: `capability-${index}`,
+        capabilityHash: `sha256:capability-${index}`,
+      });
+    }
+
+    expect(schemaCache.size()).toBe(2);
+    expect(
+      schemaCache.get({
+        serverId: mcpCapabilityRecordExample.serverId,
+        capabilityId: 'capability-0',
+        capabilityHash: 'sha256:capability-0',
+        protocolVersion: mcpCapabilityRecordExample.protocolVersion,
+      })
+    ).toBeNull();
+    expect(
+      schemaCache.get({
+        serverId: mcpCapabilityRecordExample.serverId,
+        capabilityId: 'capability-2',
+        capabilityHash: 'sha256:capability-2',
+        protocolVersion: mcpCapabilityRecordExample.protocolVersion,
+      })
+    ).not.toBeNull();
+  });
+
   it('filters and normalizes MCP capabilities before tool use', async () => {
     const gateway = new MockMCPGateway([
       {

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -280,14 +280,50 @@ export interface ToolReceiptReconciler {
 
 export interface ToolResultCacheEntry {
   validity: ToolCacheValidityRecord;
-  result: ToolCallResult;
+  result: ToolCachedResultProjection;
   createdAt: string;
+}
+
+/** Only stable, replay-safe output fields may cross invocation boundaries. */
+export interface ToolCachedResultProjection {
+  output?: unknown;
+  content?: ToolResultContent[];
+  artifactRefs?: string[];
 }
 
 export interface ToolResultCache {
   get(key: string): Promise<ToolResultCacheEntry | null>;
   set(entry: ToolResultCacheEntry): Promise<void>;
   delete?(key: string): Promise<void>;
+}
+
+export interface InMemoryToolResultCacheOptions {
+  maxEntries?: number;
+  maxEntryBytes?: number;
+}
+
+export class ToolResultCacheEntryTooLargeError extends Error {
+  readonly code = 'TOOL_RESULT_CACHE_ENTRY_TOO_LARGE';
+
+  constructor(
+    readonly actualBytes: number,
+    readonly maxEntryBytes: number
+  ) {
+    super(`Tool result cache entry is ${actualBytes} bytes; limit is ${maxEntryBytes} bytes.`);
+    this.name = 'ToolResultCacheEntryTooLargeError';
+  }
+}
+
+export class ToolResultCacheOperationTimeoutError extends Error {
+  readonly code = 'TOOL_RESULT_CACHE_TIMEOUT';
+
+  constructor(
+    readonly operation: 'get' | 'set' | 'delete',
+    readonly timeoutMs: number
+  ) {
+    super(`Tool result cache ${operation} timed out after ${timeoutMs}ms.`);
+    this.name = 'ToolResultCacheOperationTimeoutError';
+  }
 }
 
 export interface ToolObservationPort {
@@ -307,17 +343,44 @@ export interface ToolObservationPort {
 
 export class InMemoryToolResultCache implements ToolResultCache {
   private readonly entries = new Map<string, ToolResultCacheEntry>();
+  private readonly maxEntries: number;
+  private readonly maxEntryBytes: number;
+
+  constructor(options: InMemoryToolResultCacheOptions = {}) {
+    this.maxEntries = Math.max(1, options.maxEntries ?? 1_000);
+    this.maxEntryBytes = Math.max(1, options.maxEntryBytes ?? 1024 * 1024);
+  }
 
   async get(key: string): Promise<ToolResultCacheEntry | null> {
-    return this.entries.get(key) ?? null;
+    const entry = this.entries.get(key);
+    if (!entry) return null;
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    return cloneToolCacheValue(entry);
   }
 
   async set(entry: ToolResultCacheEntry): Promise<void> {
-    this.entries.set(entry.validity.key, entry);
+    const serialized = JSON.stringify(entry);
+    const actualBytes = Buffer.byteLength(serialized, 'utf8');
+    if (actualBytes > this.maxEntryBytes) {
+      throw new ToolResultCacheEntryTooLargeError(actualBytes, this.maxEntryBytes);
+    }
+    const copy = cloneToolCacheValue(entry);
+    this.entries.delete(entry.validity.key);
+    this.entries.set(entry.validity.key, copy);
+    while (this.entries.size > this.maxEntries) {
+      const oldestKey = this.entries.keys().next().value as string | undefined;
+      if (!oldestKey) break;
+      this.entries.delete(oldestKey);
+    }
   }
 
   async delete(key: string): Promise<void> {
     this.entries.delete(key);
+  }
+
+  size(): number {
+    return this.entries.size;
   }
 }
 
@@ -1035,6 +1098,8 @@ export class GovernedToolRunner implements ToolRunner {
   private readonly snapshotStore?: ToolContractSnapshotStore;
   private readonly receiptReconciler?: ToolReceiptReconciler;
   private readonly resultCache?: ToolResultCache;
+  private readonly resultCacheFailureMode: 'bypass' | 'strict';
+  private readonly resultCacheTimeoutMs: number;
   private readonly observationPort?: ToolObservationPort;
   private readonly telemetry?: TelemetryRecorder;
   private readonly inFlight = new Map<string, Promise<ToolCallResult>>();
@@ -1057,6 +1122,8 @@ export class GovernedToolRunner implements ToolRunner {
       snapshotStore?: ToolContractSnapshotStore;
       receiptReconciler?: ToolReceiptReconciler;
       resultCache?: ToolResultCache;
+      resultCacheFailureMode?: 'bypass' | 'strict';
+      resultCacheTimeoutMs?: number;
       observationPort?: ToolObservationPort;
       telemetry?: TelemetryRecorder;
       now?: () => string;
@@ -1070,6 +1137,8 @@ export class GovernedToolRunner implements ToolRunner {
     this.snapshotStore = options.snapshotStore;
     this.receiptReconciler = options.receiptReconciler;
     this.resultCache = options.resultCache;
+    this.resultCacheFailureMode = options.resultCacheFailureMode ?? 'bypass';
+    this.resultCacheTimeoutMs = Math.max(1, options.resultCacheTimeoutMs ?? 250);
     this.observationPort = options.observationPort;
     this.telemetry = options.telemetry;
     this.now = options.now ?? (() => new Date().toISOString());
@@ -1973,6 +2042,27 @@ export class GovernedToolRunner implements ToolRunner {
       return result;
     }
 
+    const cacheOperation = async <T>(
+      operation: 'get' | 'set' | 'delete',
+      task: () => Promise<T>,
+      fallback: T,
+      cacheKey?: string
+    ): Promise<T> => {
+      try {
+        return await runToolCacheOperation(operation, task, this.resultCacheTimeoutMs);
+      } catch (error) {
+        await record('tool.cache.bypass', `cache-${operation}-failed`, {
+          ...basePayload,
+          reason: 'cache_operation_failed',
+          cacheOperation: operation,
+          cacheKey,
+          code: toolCacheErrorCode(error),
+        });
+        if (this.resultCacheFailureMode === 'strict') throw error;
+        return fallback;
+      }
+    };
+
     let cacheValidity: ToolCacheValidityRecord | undefined;
     const cachePolicy = spec.cache;
     const cacheAllowed = Boolean(
@@ -2009,7 +2099,7 @@ export class GovernedToolRunner implements ToolRunner {
           : undefined,
       };
       await record('tool.cache.lookup', 'cache-lookup', { ...basePayload, cacheKey: key });
-      const cached = await this.resultCache!.get(key);
+      const cached = await cacheOperation('get', () => this.resultCache!.get(key), null, key);
       if (
         cached &&
         (!cached.validity.validUntil ||
@@ -2021,9 +2111,18 @@ export class GovernedToolRunner implements ToolRunner {
           cacheHit: true,
           durationMs: Date.now() - startedAt,
         });
-        return { ...cached.result, toolId: request.toolId, invocationId, status: 'completed' };
+        return {
+          ...cached.result,
+          toolId: request.toolId,
+          invocationId,
+          status: 'completed',
+          attempts: 0,
+          durationMs: Date.now() - startedAt,
+        };
       }
-      if (cached) await this.resultCache!.delete?.(key);
+      if (cached && this.resultCache!.delete) {
+        await cacheOperation('delete', () => this.resultCache!.delete!(key), undefined, key);
+      }
       await record('tool.cache.miss', 'cache-miss', { ...basePayload, cacheKey: key });
     } else if (cachePolicy?.mode !== 'disabled') {
       await record('tool.cache.bypass', 'cache-bypass', {
@@ -2306,15 +2405,25 @@ export class GovernedToolRunner implements ToolRunner {
           durationMs,
         };
         if (cacheValidity && this.resultCache) {
-          await this.resultCache.set({
-            validity: cacheValidity,
-            result,
-            createdAt: this.now(),
-          });
-          await record('tool.cache.write', 'cache-write', {
-            ...basePayload,
-            cacheKey: cacheValidity.key,
-          });
+          const wrote = await cacheOperation(
+            'set',
+            async () => {
+              await this.resultCache!.set({
+                validity: cacheValidity,
+                result: projectToolResultForCache(result),
+                createdAt: this.now(),
+              });
+              return true;
+            },
+            false,
+            cacheValidity.key
+          );
+          if (wrote) {
+            await record('tool.cache.write', 'cache-write', {
+              ...basePayload,
+              cacheKey: cacheValidity.key,
+            });
+          }
         }
         return result;
       } catch (error) {
@@ -3425,6 +3534,47 @@ function stringKeyword(schema: JsonSchema, key: string): string | undefined {
 
 function isJsonSchema(value: unknown): value is JsonSchema {
   return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function projectToolResultForCache(result: ToolCallResult): ToolCachedResultProjection {
+  return cloneToolCacheValue({
+    output: result.output,
+    content: result.content,
+    artifactRefs: result.artifactRefs,
+  });
+}
+
+function cloneToolCacheValue<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+async function runToolCacheOperation<T>(
+  operation: 'get' | 'set' | 'delete',
+  task: () => Promise<T>,
+  timeoutMs: number
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      task(),
+      new Promise<T>((_resolve, reject) => {
+        timeout = setTimeout(
+          () => reject(new ToolResultCacheOperationTimeoutError(operation, timeoutMs)),
+          timeoutMs
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function toolCacheErrorCode(error: unknown): string {
+  if (error && typeof error === 'object' && 'code' in error) {
+    const code = (error as { code?: unknown }).code;
+    if (typeof code === 'string') return code;
+  }
+  return 'TOOL_RESULT_CACHE_ERROR';
 }
 
 function deepEqual(left: unknown, right: unknown): boolean {

--- a/packages/tools/src/tools.test.ts
+++ b/packages/tools/src/tools.test.ts
@@ -1180,6 +1180,118 @@ describe('@hypha/tools governed runner', () => {
     );
   });
 
+  it('keeps cache failures fail-open and emits operation-specific bypass evidence', async () => {
+    const registry = new ToolRegistry();
+    const trace = new InMemoryEventStore();
+    let calls = 0;
+    registry.register(
+      {
+        id: 'tool.cache-failure',
+        version: '1.0.0',
+        revision: 'cache-failure-v1',
+        description: 'Cache failure fixture',
+        inputSchema: { type: 'object' },
+        sideEffectLevel: 'read',
+        cache: {
+          mode: 'result',
+          scope: 'run',
+          includeToolRevision: true,
+          includePolicyRevision: true,
+        },
+      },
+      async () => ({ calls: ++calls })
+    );
+    const runner = new GovernedToolRunner(registry, trace, undefined, {
+      resultCache: {
+        async get() {
+          throw Object.assign(new Error('cache unavailable'), { code: 'CACHE_UNAVAILABLE' });
+        },
+        async set() {
+          throw Object.assign(new Error('cache unavailable'), { code: 'CACHE_UNAVAILABLE' });
+        },
+      },
+    });
+
+    await expect(
+      runner.run({
+        toolId: 'tool.cache-failure',
+        input: {},
+        context: {
+          runId: 'run_tool_cache_failure',
+          stepId: 'step_cache_failure',
+          invocationId: 'invocation_cache_failure',
+        },
+      })
+    ).resolves.toMatchObject({ status: 'completed', output: { calls: 1 } });
+    expect(calls).toBe(1);
+    const events = await trace.list({ runId: 'run_tool_cache_failure' });
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'tool.cache.bypass',
+          payload: expect.objectContaining({ cacheOperation: 'get', code: 'CACHE_UNAVAILABLE' }),
+        }),
+        expect.objectContaining({
+          type: 'tool.cache.bypass',
+          payload: expect.objectContaining({ cacheOperation: 'set', code: 'CACHE_UNAVAILABLE' }),
+        }),
+      ])
+    );
+  });
+
+  it('bounds result-cache memory and never reuses invocation or receipt fields', async () => {
+    const registry = new ToolRegistry();
+    const resultCache = new InMemoryToolResultCache({ maxEntries: 2 });
+    let calls = 0;
+    registry.register(
+      {
+        id: 'tool.bounded-cache',
+        version: '1.0.0',
+        revision: 'bounded-cache-v1',
+        description: 'Bounded cache fixture',
+        inputSchema: { type: 'object' },
+        sideEffectLevel: 'read',
+        cache: {
+          mode: 'result',
+          scope: 'run',
+          includeToolRevision: true,
+          includePolicyRevision: true,
+        },
+      },
+      async (input) => {
+        const value = (input as { value: number }).value;
+        return {
+          kind: 'tool_execution_envelope',
+          output: { value, calls: ++calls },
+          externalReceipt: { receiptId: `receipt-${calls}`, status: 'observed' },
+        };
+      }
+    );
+    const runner = new GovernedToolRunner(registry, new InMemoryEventStore(), undefined, {
+      resultCache,
+    });
+    const run = (value: number, invocationId: string) =>
+      runner.run({
+        toolId: 'tool.bounded-cache',
+        input: { value },
+        context: { runId: 'run_bounded_tool_cache', stepId: 'read', invocationId },
+      });
+
+    await run(1, 'bounded-1');
+    const hit = await run(1, 'bounded-1-hit');
+    expect(hit).toMatchObject({
+      invocationId: 'bounded-1-hit',
+      output: { value: 1, calls: 1 },
+      attempts: 0,
+    });
+    expect(hit.externalReceipt).toBeUndefined();
+    await run(2, 'bounded-2');
+    await run(3, 'bounded-3');
+    expect(resultCache.size()).toBe(2);
+    await run(1, 'bounded-1-after-eviction');
+    expect(calls).toBe(4);
+  });
+
   it('honors audit inclusion and redaction policies', async () => {
     const registry = new ToolRegistry();
     registry.register(


### PR DESCRIPTION
## 变更目标

修复 Tools/MCP Owner 模块中与 Cache 相关的故障放大、跨调用生命周期字段复用和内存无界增长问题。

## 主要实现

- 工具结果缓存默认 fail-open，并为 `get`、`set`、`delete` 增加 250ms 默认超时与可选 strict 模式。
- Cache 异常通过 `tool.cache.bypass` 记录 operation 与错误码，不改变真实工具执行结果。
- 只缓存稳定的 output/content/artifact 引用；命中时重新生成 invocation 生命周期字段，不复用旧 receipt、observation、attempt 或 duration。
- `InMemoryToolResultCache` 增加条目数、单条字节数限制、LRU 淘汰和防御性复制。
- `MCPSchemaCache` 增加可配置容量、LRU 淘汰和确定性时间源。

## 验证

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`（65/65）
- `npm run test:packages`（136 suites / 1028 tests）
- Tools/MCP focused tests（50/50）
- `git diff --check`

## 所有权说明

变更仅涉及 `packages/tools` 与 `packages/mcp` 及其测试，先同步当前 `dev` 后在 `tools` Owner source branch 实现。
