### PR TITLE
fix(inference): bound and scope hot caches

### DIFF
--- a/packages/inference/src/cache.ts
+++ b/packages/inference/src/cache.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'crypto';
 import type {
+  InferenceCacheScope,
   KvCacheProvider,
   KvCacheRef,
   KvCacheScope,
@@ -12,6 +13,7 @@ export interface PrefixCacheCreateInput {
   version: string;
   content: string;
   tokenCount?: number;
+  cacheScope?: InferenceCacheScope;
   metadata?: Record<string, unknown>;
 }
 
@@ -20,6 +22,7 @@ export interface KvCacheCreateInput {
   provider: string;
   modelAlias: string;
   scope: KvCacheScope;
+  cacheScope?: InferenceCacheScope;
   ttlMs?: number;
   metadata?: Record<string, unknown>;
 }
@@ -43,6 +46,7 @@ export class InferenceCacheManager {
       version: input.version,
       contentHash: hashContent(input.content),
       tokenCount: input.tokenCount,
+      cacheScope: input.cacheScope,
       metadata: input.metadata,
     };
     await this.options.prefixCache.put(ref, input.content);
@@ -54,14 +58,16 @@ export class InferenceCacheManager {
   }
 
   async putKv(input: KvCacheCreateInput, value: unknown): Promise<KvCacheRef> {
-    const expiresAt = input.ttlMs !== undefined
-      ? new Date(this.now().getTime() + input.ttlMs).toISOString()
-      : undefined;
+    const expiresAt =
+      input.ttlMs !== undefined
+        ? new Date(this.now().getTime() + input.ttlMs).toISOString()
+        : undefined;
     const ref: KvCacheRef = {
       id: input.id,
       provider: input.provider,
       modelAlias: input.modelAlias,
       scope: input.scope,
+      cacheScope: input.cacheScope,
       expiresAt,
       metadata: input.metadata,
     };
@@ -80,6 +86,13 @@ export class InferenceCacheManager {
 
 export function hashContent(content: string): string {
   return createHash('sha256').update(content).digest('hex');
+}
+
+export function inferenceCacheScopeHash(scope: InferenceCacheScope | undefined): string {
+  if (!scope?.userId) return 'unscoped';
+  return createHash('sha256')
+    .update([scope.tenantId ?? '', scope.userId, scope.workspaceId ?? ''].join('\u0000'))
+    .digest('hex');
 }
 
 export function isKvCacheExpired(ref: KvCacheRef, now: Date = new Date()): boolean {

--- a/packages/inference/src/manager.test.ts
+++ b/packages/inference/src/manager.test.ts
@@ -21,6 +21,7 @@ import type {
   InferenceBackendRequest,
   InferenceProvider,
   KvCacheProvider,
+  PrefixSegmentationResult,
   PrefixCacheProvider,
 } from './types';
 
@@ -346,6 +347,68 @@ describe('@hypha/inference', () => {
       now: () => new Date('2026-07-02T00:00:01.000Z'),
     });
     await expect(expiredManager.getKv(kv)).resolves.toBeNull();
+  });
+
+  it('bounds in-memory prefix and KV providers with LRU eviction', async () => {
+    const prefixCache = new InMemoryPrefixCacheProvider({
+      maxEntries: 2,
+      maxEntryBytes: 64,
+      maxTotalBytes: 64,
+    });
+    const manager = new InferenceCacheManager({
+      prefixCache,
+      kvCache: new InMemoryKvCacheProvider(),
+    });
+    const first = await manager.putPrefix({ id: 'first', version: '1', content: 'first' });
+    const second = await manager.putPrefix({ id: 'second', version: '1', content: 'second' });
+    await expect(manager.getPrefix(first)).resolves.toBe('first');
+    const third = await manager.putPrefix({ id: 'third', version: '1', content: 'third' });
+    await expect(manager.getPrefix(second)).resolves.toBeNull();
+    await expect(manager.getPrefix(first)).resolves.toBe('first');
+    await expect(manager.getPrefix(third)).resolves.toBe('third');
+    expect(prefixCache.stats()).toEqual({ entries: 2, totalBytes: 10 });
+    await expect(
+      manager.putPrefix({ id: 'oversized', version: '1', content: 'x'.repeat(65) })
+    ).rejects.toMatchObject({ code: 'INFERENCE_CACHE_CAPACITY_EXCEEDED' });
+
+    const kvCache = new InMemoryKvCacheProvider({ maxEntries: 2 });
+    const refs = [0, 1, 2].map((index) => ({
+      id: `kv-${index}`,
+      provider: 'fixture',
+      modelAlias: 'default',
+      scope: 'run' as const,
+    }));
+    await kvCache.put(refs[0], { value: 0 });
+    await kvCache.put(refs[1], { value: 1 });
+    await expect(kvCache.get(refs[0])).resolves.toEqual({ value: 0 });
+    await kvCache.put(refs[2], { value: 2 });
+    expect(kvCache.size()).toBe(2);
+    await expect(kvCache.get(refs[1])).resolves.toBeNull();
+  });
+
+  it('separates identical inference cache references by user scope', async () => {
+    const prefixCache = new InMemoryPrefixCacheProvider();
+    const prefixBase = { id: 'shared', version: '1', contentHash: 'a'.repeat(64) };
+    const prefixA = { ...prefixBase, cacheScope: { userId: 'user-a' } };
+    const prefixB = { ...prefixBase, cacheScope: { userId: 'user-b' } };
+    await prefixCache.put(prefixA, 'content-a');
+    await prefixCache.put(prefixB, 'content-b');
+    await expect(prefixCache.get(prefixA)).resolves.toBe('content-a');
+    await expect(prefixCache.get(prefixB)).resolves.toBe('content-b');
+
+    const kvCache = new InMemoryKvCacheProvider();
+    const kvBase = {
+      id: 'shared',
+      provider: 'fixture',
+      modelAlias: 'default',
+      scope: 'session' as const,
+    };
+    const kvA = { ...kvBase, cacheScope: { userId: 'user-a' } };
+    const kvB = { ...kvBase, cacheScope: { userId: 'user-b' } };
+    await kvCache.put(kvA, { owner: 'a' });
+    await kvCache.put(kvB, { owner: 'b' });
+    await expect(kvCache.get(kvA)).resolves.toEqual({ owner: 'a' });
+    await expect(kvCache.get(kvB)).resolves.toEqual({ owner: 'b' });
   });
 
   it('enforces KV cache expiry on inference manager reads', async () => {
@@ -714,6 +777,7 @@ describe('@hypha/inference', () => {
       agentId: 'agent_plasmod',
       modelAlias: 'default-chat',
       backendId: 'sglang',
+      cacheScope: { userId: 'user-plasmod' },
       segmentation: segmented,
     });
     const second = await hotLayer.prepare({
@@ -723,6 +787,7 @@ describe('@hypha/inference', () => {
       agentId: 'agent_plasmod',
       modelAlias: 'default-chat',
       backendId: 'sglang',
+      cacheScope: { userId: 'user-plasmod' },
       segmentation: segmented,
     });
 
@@ -749,6 +814,97 @@ describe('@hypha/inference', () => {
 
     await hotLayer.invalidateSegment(ref.id, 'test');
     expect(hotLayer.getCacheMetadata(ref.id)).toBeNull();
+  });
+
+  it('keeps Plasmod reuse inside the hard user scope even when cross-session reuse is enabled', async () => {
+    const compiled = await new DefaultPromptCompiler().compile({
+      runId: 'run_scope_a1',
+      stepId: 'step_scope',
+      sessionId: 'session_a1',
+      agentId: 'agent_scope',
+      modelAlias: 'default-chat',
+      instructions: 'Stable scoped prefix.',
+      input: 'Dynamic input.',
+    });
+    const segmented = await new DefaultPrefixSegmenter().segment(compiled);
+    const hotLayer = new InMemoryPlasmodHotLayer();
+    const prepare = (userId: string, sessionId: string, runId: string) =>
+      hotLayer.prepare({
+        runId,
+        stepId: 'step_scope',
+        sessionId,
+        agentId: 'agent_scope',
+        modelAlias: 'default-chat',
+        backendId: 'sglang',
+        cacheScope: { userId },
+        segmentation: segmented,
+        reusePolicy: { allowCrossSession: true, allowCrossAgent: true },
+      });
+
+    const userAFirst = await prepare('user-a', 'session-a1', 'run-a1');
+    const userB = await prepare('user-b', 'session-b1', 'run-b1');
+    const userASecond = await prepare('user-a', 'session-a2', 'run-a2');
+
+    expect(userAFirst.reusedSegmentIds).toHaveLength(0);
+    expect(userB.reusedSegmentIds).toHaveLength(0);
+    expect(userB.prefixRefs[0]?.id).not.toBe(userAFirst.prefixRefs[0]?.id);
+    expect(userASecond.reusedSegmentIds).toEqual([userAFirst.prefixRefs[0]?.id]);
+  });
+
+  it('bounds Plasmod segments, states, aliases, reuse keys, and dependency fan-out', async () => {
+    const hotLayer = new InMemoryPlasmodHotLayer({
+      maxSegments: 1,
+      maxSessionStates: 1,
+      maxAliases: 1,
+      maxReuseKeys: 1,
+      maxDependenciesPerSegment: 1,
+    });
+    const segmentation = (
+      id: string,
+      contentHash: string,
+      dependencies: string[] = []
+    ): PrefixSegmentationResult => ({
+      compiled: { id: `compiled-${id}`, messages: [], text: id },
+      segments: [
+        {
+          id,
+          kind: 'system',
+          scope: 'agent',
+          content: id,
+          contentHash,
+          tokenCount: 4,
+          cacheable: true,
+          dependencies,
+        },
+      ],
+      stablePrefix: id,
+      dynamicPrompt: '',
+    });
+    const prepare = (id: string, hash: string, dependencies: string[] = []) =>
+      hotLayer.prepare({
+        runId: `run-${id}`,
+        stepId: 'step-bounded',
+        sessionId: `session-${id}`,
+        agentId: 'agent-bounded',
+        modelAlias: 'default-chat',
+        backendId: 'sglang',
+        cacheScope: { userId: 'user-bounded' },
+        segmentation: segmentation(id, hash, dependencies),
+      });
+
+    const first = await prepare('first', 'a'.repeat(64));
+    const second = await prepare('second', 'b'.repeat(64));
+    expect(second.invalidatedSegmentIds).toContain(first.prefixRefs[0]?.id);
+    expect(hotLayer.snapshot()).toMatchObject({
+      prefixRegistrySize: 1,
+      cacheMetadataSize: 1,
+      sessionStateSize: 1,
+      segmentAliasSize: 1,
+      reuseKeySize: 1,
+    });
+    const skipped = await prepare('fan-out', 'c'.repeat(64), ['dep-1', 'dep-2']);
+    expect(skipped.prefixRefs).toHaveLength(0);
+    expect(hotLayer.snapshot().invalidationGraphSize).toBeLessThanOrEqual(1);
   });
 
   it('registers all inference backends and defaults to SGLang', () => {

--- a/packages/inference/src/manager.ts
+++ b/packages/inference/src/manager.ts
@@ -1,4 +1,5 @@
 import { FrameworkError, type RecoveryFailure } from '@hypha/core';
+import { inferenceCacheScopeHash } from './cache';
 import { isKvCacheExpired } from './cache';
 import { classifyInferenceCacheFailure, classifyInferenceFailure } from './recovery';
 import type {
@@ -329,43 +330,127 @@ export class InferenceManager {
   }
 }
 
+export interface InMemoryPrefixCacheProviderOptions {
+  maxEntries?: number;
+  maxEntryBytes?: number;
+  maxTotalBytes?: number;
+}
+
+export interface InMemoryKvCacheProviderOptions {
+  maxEntries?: number;
+}
+
+export class InferenceCacheCapacityError extends Error {
+  readonly code = 'INFERENCE_CACHE_CAPACITY_EXCEEDED';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'InferenceCacheCapacityError';
+  }
+}
+
 export class InMemoryPrefixCacheProvider implements PrefixCacheProvider {
-  private readonly records = new Map<string, string>();
+  private readonly records = new Map<string, { content: string; bytes: number }>();
+  private readonly maxEntries: number;
+  private readonly maxEntryBytes: number;
+  private readonly maxTotalBytes: number;
+  private totalBytes = 0;
+
+  constructor(options: InMemoryPrefixCacheProviderOptions = {}) {
+    this.maxEntries = Math.max(1, options.maxEntries ?? 1_000);
+    this.maxEntryBytes = Math.max(1, options.maxEntryBytes ?? 4 * 1024 * 1024);
+    this.maxTotalBytes = Math.max(this.maxEntryBytes, options.maxTotalBytes ?? 64 * 1024 * 1024);
+  }
 
   async get(ref: PrefixCacheRef): Promise<string | null> {
-    return this.records.get(this.key(ref)) ?? null;
+    const key = this.key(ref);
+    const record = this.records.get(key);
+    if (!record) return null;
+    this.records.delete(key);
+    this.records.set(key, record);
+    return record.content;
   }
 
   async put(ref: PrefixCacheRef, content: string): Promise<void> {
-    this.records.set(this.key(ref), content);
+    const bytes = Buffer.byteLength(content, 'utf8');
+    if (bytes > this.maxEntryBytes) {
+      throw new InferenceCacheCapacityError(
+        `Prefix cache entry is ${bytes} bytes; limit is ${this.maxEntryBytes} bytes.`
+      );
+    }
+    const key = this.key(ref);
+    const previous = this.records.get(key);
+    if (previous) this.totalBytes -= previous.bytes;
+    this.records.delete(key);
+    this.records.set(key, { content, bytes });
+    this.totalBytes += bytes;
+    this.prune();
   }
 
   async invalidate(ref: PrefixCacheRef): Promise<void> {
-    this.records.delete(this.key(ref));
+    const key = this.key(ref);
+    const existing = this.records.get(key);
+    if (existing) this.totalBytes -= existing.bytes;
+    this.records.delete(key);
+  }
+
+  stats(): { entries: number; totalBytes: number } {
+    return { entries: this.records.size, totalBytes: this.totalBytes };
   }
 
   private key(ref: PrefixCacheRef): string {
-    return `${ref.id}:${ref.version}:${ref.contentHash}`;
+    return `${inferenceCacheScopeHash(ref.cacheScope)}:${ref.id}:${ref.version}:${ref.contentHash}`;
+  }
+
+  private prune(): void {
+    while (this.records.size > this.maxEntries || this.totalBytes > this.maxTotalBytes) {
+      const oldestKey = this.records.keys().next().value as string | undefined;
+      if (!oldestKey) break;
+      const oldest = this.records.get(oldestKey);
+      if (oldest) this.totalBytes -= oldest.bytes;
+      this.records.delete(oldestKey);
+    }
   }
 }
 
 export class InMemoryKvCacheProvider implements KvCacheProvider {
   private readonly records = new Map<string, unknown>();
+  private readonly maxEntries: number;
+
+  constructor(options: InMemoryKvCacheProviderOptions = {}) {
+    this.maxEntries = Math.max(1, options.maxEntries ?? 1_000);
+  }
 
   async get(ref: KvCacheRef): Promise<unknown | null> {
-    const value = this.records.get(this.key(ref));
+    const key = this.key(ref);
+    const value = this.records.get(key);
+    if (value !== undefined) {
+      this.records.delete(key);
+      this.records.set(key, value);
+    }
     return value === undefined ? null : value;
   }
 
   async put(ref: KvCacheRef, value: unknown): Promise<void> {
-    this.records.set(this.key(ref), value);
+    const key = this.key(ref);
+    this.records.delete(key);
+    this.records.set(key, value);
+    while (this.records.size > this.maxEntries) {
+      const oldestKey = this.records.keys().next().value as string | undefined;
+      if (!oldestKey) break;
+      this.records.delete(oldestKey);
+    }
   }
 
   async invalidate(ref: KvCacheRef): Promise<void> {
     this.records.delete(this.key(ref));
   }
 
+  size(): number {
+    return this.records.size;
+  }
+
   private key(ref: KvCacheRef): string {
-    return `${ref.scope}:${ref.provider}:${ref.modelAlias}:${ref.id}`;
+    return `${inferenceCacheScopeHash(ref.cacheScope)}:${ref.scope}:${ref.provider}:${ref.modelAlias}:${ref.id}`;
   }
 }

--- a/packages/inference/src/pipeline.ts
+++ b/packages/inference/src/pipeline.ts
@@ -96,6 +96,7 @@ export class HyphaInferencePipeline implements InferenceProvider {
       agentId: request.agentId,
       modelAlias: request.modelAlias,
       backendId: backend.id,
+      cacheScope: request.cacheScope ?? inferenceCacheScopeFromMetadata(request.metadata),
       segmentation,
       kvCache: request.cachePolicy?.kvCache ?? request.kvCache,
       resolvedKvCacheValue: request.resolvedKvCacheValue,
@@ -158,6 +159,22 @@ export class HyphaInferencePipeline implements InferenceProvider {
       raw: response.raw,
     };
   }
+}
+
+function inferenceCacheScopeFromMetadata(
+  metadata: Record<string, unknown> | undefined
+): InferenceRequest['cacheScope'] {
+  const userId = stringMetadata(metadata?.userId);
+  if (!userId) return undefined;
+  return {
+    userId,
+    tenantId: stringMetadata(metadata?.tenantId),
+    workspaceId: stringMetadata(metadata?.workspaceId),
+  };
+}
+
+function stringMetadata(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 function numberFromMetadata(value: unknown): number | undefined {

--- a/packages/inference/src/plasmod.ts
+++ b/packages/inference/src/plasmod.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import type {
   KvCacheRef,
   PlasmodCacheMetadata,
@@ -18,6 +19,15 @@ const DEFAULT_REUSE_POLICY: Required<PlasmodReusePolicy> = {
   maxPrefixRefs: 32,
 };
 
+export interface InMemoryPlasmodHotLayerOptions {
+  now?: () => Date;
+  maxSegments?: number;
+  maxSessionStates?: number;
+  maxAliases?: number;
+  maxReuseKeys?: number;
+  maxDependenciesPerSegment?: number;
+}
+
 export class InMemoryPlasmodHotLayer implements PlasmodHotLayer {
   private readonly prefixRegistry = new Map<string, PrefixSegment>();
   private readonly cacheMetadata = new Map<string, PlasmodCacheMetadata>();
@@ -25,21 +35,36 @@ export class InMemoryPlasmodHotLayer implements PlasmodHotLayer {
   private readonly invalidationGraph = new Map<string, Set<string>>();
   private readonly registryByReuseKey = new Map<string, string>();
   private readonly segmentAliases = new Map<string, string>();
+  private readonly now: () => Date;
+  private readonly maxSegments: number;
+  private readonly maxSessionStates: number;
+  private readonly maxAliases: number;
+  private readonly maxReuseKeys: number;
+  private readonly maxDependenciesPerSegment: number;
 
-  constructor(private readonly now: () => Date = () => new Date()) {}
+  constructor(nowOrOptions: (() => Date) | InMemoryPlasmodHotLayerOptions = {}) {
+    const options = typeof nowOrOptions === 'function' ? { now: nowOrOptions } : nowOrOptions;
+    this.now = options.now ?? (() => new Date());
+    this.maxSegments = Math.max(1, options.maxSegments ?? 10_000);
+    this.maxSessionStates = Math.max(1, options.maxSessionStates ?? 10_000);
+    this.maxAliases = Math.max(1, options.maxAliases ?? this.maxSegments * 4);
+    this.maxReuseKeys = Math.max(1, options.maxReuseKeys ?? this.maxSegments * 4);
+    this.maxDependenciesPerSegment = Math.max(0, options.maxDependenciesPerSegment ?? 64);
+  }
 
   async prepare(input: PlasmodHotLayerPrepareInput): Promise<PlasmodHotLayerPrepareResult> {
     const policy = normalizeReusePolicy(input.reusePolicy);
     const now = this.now().toISOString();
     const prefixRefs: PrefixCacheRef[] = [];
     const reusedSegmentIds: string[] = [];
+    const invalidatedSegmentIds = new Set<string>();
 
     for (const segment of input.segmentation.segments) {
       if (!this.isReusable(segment, policy)) continue;
       if (prefixRefs.length >= policy.maxPrefixRefs) break;
 
-      const segmentId = this.segmentId(segment);
       const reuseKey = this.reuseKey(segment, input, policy);
+      const segmentId = this.segmentId(segment, reuseKey);
       const existingSegmentId = this.registryByReuseKey.get(reuseKey);
       const existing = existingSegmentId ? this.cacheMetadata.get(existingSegmentId) : undefined;
       const reused = Boolean(
@@ -47,10 +72,13 @@ export class InMemoryPlasmodHotLayer implements PlasmodHotLayer {
       );
       const refId = reused && existingSegmentId ? existingSegmentId : segmentId;
 
-      this.segmentAliases.set(segment.id, refId);
+      this.touchBounded(this.segmentAliases, segment.id, refId, this.maxAliases);
+      this.prefixRegistry.delete(refId);
       this.prefixRegistry.set(refId, segment);
-      this.registryByReuseKey.set(reuseKey, refId);
+      this.touchBounded(this.registryByReuseKey, reuseKey, refId, this.maxReuseKeys);
+      this.removeIncomingEdges(refId);
       this.recordInvalidationEdges(refId, segment.dependencies ?? []);
+      this.cacheMetadata.delete(refId);
       this.cacheMetadata.set(refId, {
         segmentId: refId,
         contentHash: segment.contentHash,
@@ -68,8 +96,11 @@ export class InMemoryPlasmodHotLayer implements PlasmodHotLayer {
           sessionId: input.sessionId,
           runId: input.runId,
           agentId: input.agentId,
+          cacheScopeHash: this.scopeId(input),
         },
       });
+
+      for (const evicted of this.enforceSegmentLimit()) invalidatedSegmentIds.add(evicted);
 
       if (reused) reusedSegmentIds.push(refId);
       prefixRefs.push({
@@ -77,6 +108,7 @@ export class InMemoryPlasmodHotLayer implements PlasmodHotLayer {
         version: `${input.backendId}:${input.modelAlias}`,
         contentHash: segment.contentHash,
         tokenCount: segment.tokenCount,
+        cacheScope: input.cacheScope,
         metadata: {
           kind: segment.kind,
           scope: segment.scope,
@@ -87,8 +119,13 @@ export class InMemoryPlasmodHotLayer implements PlasmodHotLayer {
       });
     }
 
+    const activePrefixRefs = prefixRefs.filter((ref) => !invalidatedSegmentIds.has(ref.id));
+    const activeReusedSegmentIds = reusedSegmentIds.filter(
+      (segmentId) => !invalidatedSegmentIds.has(segmentId)
+    );
     const kvCacheRef = input.kvCache ?? createKvCacheRef(input);
     const stateId = this.stateId(input);
+    this.sessionState.delete(stateId);
     this.sessionState.set(stateId, {
       id: stateId,
       sessionId: input.sessionId,
@@ -96,23 +133,24 @@ export class InMemoryPlasmodHotLayer implements PlasmodHotLayer {
       agentId: input.agentId,
       modelAlias: input.modelAlias,
       backendId: input.backendId,
-      prefixRefs,
+      prefixRefs: activePrefixRefs,
       kvCacheRef,
       updatedAt: now,
       metadata: input.metadata,
     });
+    this.enforceSessionStateLimit();
 
     return {
-      prefixRefs,
+      prefixRefs: activePrefixRefs,
       kvCacheRef,
       physicalKvCache: input.resolvedKvCacheValue,
-      reusedSegmentIds,
-      invalidatedSegmentIds: [],
+      reusedSegmentIds: activeReusedSegmentIds,
+      invalidatedSegmentIds: Array.from(invalidatedSegmentIds),
       metadata: {
         stateId,
-        reusedSegmentCount: reusedSegmentIds.length,
-        reusedTokens: prefixRefs
-          .filter((ref) => reusedSegmentIds.includes(ref.id))
+        reusedSegmentCount: activeReusedSegmentIds.length,
+        reusedTokens: activePrefixRefs
+          .filter((ref) => activeReusedSegmentIds.includes(ref.id))
           .reduce((sum, ref) => sum + (ref.tokenCount ?? 0), 0),
         prefixRegistrySize: this.prefixRegistry.size,
         cacheMetadataSize: this.cacheMetadata.size,
@@ -126,11 +164,24 @@ export class InMemoryPlasmodHotLayer implements PlasmodHotLayer {
   }
 
   getSessionState(stateId: string): PlasmodSessionState | null {
-    return this.sessionState.get(stateId) ?? null;
+    const state = this.sessionState.get(stateId);
+    if (!state) return null;
+    this.sessionState.delete(stateId);
+    this.sessionState.set(stateId, state);
+    return state;
   }
 
   getCacheMetadata(segmentId: string): PlasmodCacheMetadata | null {
-    return this.cacheMetadata.get(segmentId) ?? null;
+    const metadata = this.cacheMetadata.get(segmentId);
+    if (!metadata) return null;
+    const segment = this.prefixRegistry.get(segmentId);
+    if (segment) {
+      this.prefixRegistry.delete(segmentId);
+      this.prefixRegistry.set(segmentId, segment);
+    }
+    this.cacheMetadata.delete(segmentId);
+    this.cacheMetadata.set(segmentId, metadata);
+    return metadata;
   }
 
   snapshot(): {
@@ -138,27 +189,35 @@ export class InMemoryPlasmodHotLayer implements PlasmodHotLayer {
     cacheMetadataSize: number;
     sessionStateSize: number;
     invalidationGraphSize: number;
+    segmentAliasSize: number;
+    reuseKeySize: number;
   } {
     return {
       prefixRegistrySize: this.prefixRegistry.size,
       cacheMetadataSize: this.cacheMetadata.size,
       sessionStateSize: this.sessionState.size,
       invalidationGraphSize: this.invalidationGraph.size,
+      segmentAliasSize: this.segmentAliases.size,
+      reuseKeySize: this.registryByReuseKey.size,
     };
   }
 
   private isReusable(segment: PrefixSegment, policy: Required<PlasmodReusePolicy>): boolean {
-    return segment.cacheable && (segment.tokenCount ?? 0) >= policy.minTokenCount;
+    return (
+      segment.cacheable &&
+      (segment.tokenCount ?? 0) >= policy.minTokenCount &&
+      (segment.dependencies?.length ?? 0) <= this.maxDependenciesPerSegment
+    );
   }
 
-  private segmentId(segment: PrefixSegment): string {
-    return `prefix:${segment.scope}:${segment.kind}:${segment.contentHash.slice(0, 24)}`;
+  private segmentId(segment: PrefixSegment, reuseKey: string): string {
+    return `prefix:${segment.scope}:${segment.kind}:${segment.contentHash.slice(0, 24)}:${shortHash(reuseKey)}`;
   }
 
   private stateId(input: PlasmodHotLayerPrepareInput): string {
     const sessionKey = input.sessionId ?? 'no-session';
     const agentKey = input.agentId ?? 'no-agent';
-    return `${sessionKey}:${input.runId}:${agentKey}:${input.backendId}:${input.modelAlias}`;
+    return `${this.scopeId(input)}:${sessionKey}:${input.runId}:${agentKey}:${input.backendId}:${input.modelAlias}`;
   }
 
   private reuseKey(
@@ -167,6 +226,7 @@ export class InMemoryPlasmodHotLayer implements PlasmodHotLayer {
     policy: Required<PlasmodReusePolicy>
   ): string {
     const parts = [
+      this.scopeId(input),
       input.backendId,
       input.modelAlias,
       segment.scope,
@@ -179,12 +239,56 @@ export class InMemoryPlasmodHotLayer implements PlasmodHotLayer {
     return parts.join(':');
   }
 
+  private scopeId(input: PlasmodHotLayerPrepareInput): string {
+    return plasmodScopeId(input);
+  }
+
   private recordInvalidationEdges(segmentId: string, dependencies: string[]): void {
     for (const dependency of dependencies) {
       const normalizedDependencyId = this.normalizeDependencyId(dependency);
       const dependents = this.invalidationGraph.get(normalizedDependencyId) ?? new Set<string>();
       dependents.add(segmentId);
       this.invalidationGraph.set(normalizedDependencyId, dependents);
+    }
+  }
+
+  private removeIncomingEdges(segmentId: string): void {
+    for (const [dependencyId, dependents] of this.invalidationGraph) {
+      dependents.delete(segmentId);
+      if (dependents.size === 0) this.invalidationGraph.delete(dependencyId);
+    }
+  }
+
+  private enforceSegmentLimit(): Set<string> {
+    const invalidated = new Set<string>();
+    while (this.prefixRegistry.size > this.maxSegments) {
+      const oldestSegmentId = this.prefixRegistry.keys().next().value as string | undefined;
+      if (!oldestSegmentId) break;
+      this.invalidateRecursive(oldestSegmentId, invalidated);
+    }
+    return invalidated;
+  }
+
+  private enforceSessionStateLimit(): void {
+    while (this.sessionState.size > this.maxSessionStates) {
+      const oldestStateId = this.sessionState.keys().next().value as string | undefined;
+      if (!oldestStateId) break;
+      this.sessionState.delete(oldestStateId);
+    }
+  }
+
+  private touchBounded<TKey, TValue>(
+    target: Map<TKey, TValue>,
+    key: TKey,
+    value: TValue,
+    limit: number
+  ): void {
+    target.delete(key);
+    target.set(key, value);
+    while (target.size > limit) {
+      const oldestKey = target.keys().next().value as TKey | undefined;
+      if (oldestKey === undefined) break;
+      target.delete(oldestKey);
     }
   }
 
@@ -199,6 +303,9 @@ export class InMemoryPlasmodHotLayer implements PlasmodHotLayer {
     if (visited.has(segmentId)) return;
     visited.add(segmentId);
 
+    const dependents = new Set(this.invalidationGraph.get(segmentId) ?? []);
+    this.invalidationGraph.delete(segmentId);
+    this.removeIncomingEdges(segmentId);
     this.prefixRegistry.delete(segmentId);
     this.cacheMetadata.delete(segmentId);
     for (const [key, value] of Array.from(this.registryByReuseKey.entries())) {
@@ -207,9 +314,12 @@ export class InMemoryPlasmodHotLayer implements PlasmodHotLayer {
     for (const [key, value] of Array.from(this.segmentAliases.entries())) {
       if (value === segmentId) this.segmentAliases.delete(key);
     }
-
-    const dependents = this.invalidationGraph.get(segmentId) ?? new Set<string>();
-    this.invalidationGraph.delete(segmentId);
+    for (const [stateId, state] of this.sessionState) {
+      const prefixRefs = state.prefixRefs.filter((ref) => ref.id !== segmentId);
+      if (prefixRefs.length !== state.prefixRefs.length) {
+        this.sessionState.set(stateId, { ...state, prefixRefs });
+      }
+    }
     for (const dependent of dependents) {
       this.invalidateRecursive(dependent, visited);
     }
@@ -225,16 +335,31 @@ function normalizeReusePolicy(policy: PlasmodReusePolicy = {}): Required<Plasmod
 
 function createKvCacheRef(input: PlasmodHotLayerPrepareInput): KvCacheRef {
   const scope = input.sessionId ? 'session' : 'run';
+  const cacheScopeHash = plasmodScopeId(input);
   return {
-    id: `kv:${input.backendId}:${input.modelAlias}:${scope}:${input.sessionId ?? input.runId}`,
+    id: `kv:${input.backendId}:${input.modelAlias}:${cacheScopeHash}:${scope}:${input.sessionId ?? input.runId}`,
     provider: input.backendId,
     modelAlias: input.modelAlias,
     scope,
+    cacheScope: input.cacheScope,
     metadata: {
       source: 'plasmod',
       runId: input.runId,
       sessionId: input.sessionId,
       agentId: input.agentId,
+      cacheScopeHash,
     },
   };
+}
+
+function plasmodScopeId(input: PlasmodHotLayerPrepareInput): string {
+  const scope = input.cacheScope;
+  if (!scope?.userId) return `run-${shortHash(input.runId)}`;
+  return `user-${shortHash(
+    [scope.tenantId ?? '', scope.userId, scope.workspaceId ?? ''].join('\u0000')
+  )}`;
+}
+
+function shortHash(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 16);
 }

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -10,12 +10,19 @@ export interface InferenceRequest<TInput = unknown> {
   options?: InferenceGenerationOptions;
   tools?: InferenceToolDescriptor[];
   cachePolicy?: InferenceCachePolicy;
+  cacheScope?: InferenceCacheScope;
   prefix?: PrefixCacheRef;
   resolvedPrefixContent?: string;
   kvCache?: KvCacheRef;
   resolvedKvCacheValue?: unknown;
   trace?: boolean;
   metadata?: Record<string, unknown>;
+}
+
+export interface InferenceCacheScope {
+  tenantId?: string;
+  userId: string;
+  workspaceId?: string;
 }
 
 export interface InferenceToolDescriptor {
@@ -58,6 +65,7 @@ export interface PrefixCacheRef {
   version: string;
   contentHash: string;
   tokenCount?: number;
+  cacheScope?: InferenceCacheScope;
   metadata?: Record<string, unknown>;
 }
 
@@ -66,6 +74,7 @@ export interface KvCacheRef {
   provider: string;
   modelAlias: string;
   scope: KvCacheScope;
+  cacheScope?: InferenceCacheScope;
   expiresAt?: string;
   metadata?: Record<string, unknown>;
 }
@@ -253,6 +262,7 @@ export interface PlasmodHotLayerPrepareInput {
   agentId?: string;
   modelAlias: string;
   backendId: string;
+  cacheScope?: InferenceCacheScope;
   segmentation: PrefixSegmentationResult;
   kvCache?: KvCacheRef;
   resolvedKvCacheValue?: unknown;


### PR DESCRIPTION
## 变更目标

修复 Inference Owner 模块的 Prefix/KV/Plasmod 热缓存作用域碰撞、无界内存增长和失效图残留问题。

## 主要实现

- 为 Inference cache refs 增加明确的 tenant/user/workspace scope，并让内存 Provider 的键包含作用域哈希。
- Plasmod 始终使用用户硬边界；没有用户作用域的旧调用退化为 run 隔离，避免跨运行误复用。
- 物理 segment ID 纳入完整 reuse identity 哈希，修复“策略禁止跨会话但同内容 ID 仍碰撞”的问题。
- Prefix Provider 增加条目、单条字节、总字节 LRU；KV Provider 增加条目 LRU。
- Plasmod 为 segments、session states、aliases、reuse keys、dependency fan-out 增加边界。
- 淘汰和失效同步清理复用索引、别名、依赖图与会话引用；被淘汰的引用不再传给后端。
- Pipeline 支持显式 `cacheScope`，并兼容从经过治理的 metadata 提取用户作用域。

## 验证

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`（65/65）
- `npm run test:packages`（136 suites / 1032 tests）
- Inference focused tests（24/24）
- `git diff --check`

## 所有权说明

变更仅涉及 `packages/inference` 及其测试，先同步当前 `dev` 后在 `inference` Owner source branch 实现。
