### PR TITLE
fix(runtime): scope recovery cache knowledge

### DIFF
--- a/apps/server/src/services/EventRuntime.ts
+++ b/apps/server/src/services/EventRuntime.ts
@@ -705,6 +705,7 @@ class EventRuntimeService {
       sessionId: runContext?.clientSessionId,
       modelAlias: resolved.model,
       cachePolicy: input.cachePolicy,
+      cacheScope: { userId: runContext?.userId ?? 'single-user' },
       input: {
         messages: input.messages,
         options: {
@@ -1060,6 +1061,7 @@ class EventRuntimeService {
       sessionId: runContext?.clientSessionId,
       modelAlias: resolved.model,
       cachePolicy: input.cachePolicy,
+      cacheScope: { userId: runContext?.userId ?? 'single-user' },
       input: {
         messages: input.messages,
         options: {
@@ -1743,9 +1745,11 @@ class EventRuntimeService {
     const result = await runRecoverySupervisor({
       fsm: recoveryFsm,
       caseId: input.caseId,
+      userId: context.userId,
       participants: [input.participant],
       knowledge: this.recoveryKnowledge,
       sessionId: context.sessionId,
+      domainPackId: context.domainPackId,
       stepId: input.stepId,
       metadata: {
         userId: context.userId,
@@ -1794,12 +1798,18 @@ class EventRuntimeService {
     if (failure.module !== 'cache') return;
     const runId = stringValue(failure.metadata?.runId);
     if (!runId || !this.runs.has(runId)) return;
+    const context = this.runs.get(runId)!;
     const stepId = stringValue(failure.metadata?.stepId);
     const fingerprint = recoveryFailureFingerprint(failure);
     const knowledge: RecoveryKnowledge = {
       key: {
         fingerprint,
         participantId: 'inference-cache',
+        scope: {
+          userId: context.userId,
+          sessionId: context.sessionId,
+          domainPackId: context.domainPackId,
+        },
         policyRevision: failure.evidence.policyRevision,
         specRevision: failure.evidence.specRevision,
         providerRevision: failure.evidence.providerRevision,

--- a/packages/core/src/contracts/recovery-knowledge-schemas.ts
+++ b/packages/core/src/contracts/recovery-knowledge-schemas.ts
@@ -1,0 +1,136 @@
+import { z, type ZodType } from 'zod';
+import type { JsonSchema } from '../specs';
+import {
+  RECOVERY_STRATEGIES,
+  type RecoveryKnowledge,
+  type RecoveryKnowledgeKey,
+  type RecoveryKnowledgeScope,
+} from './recovery';
+
+const nonEmptyStringSchema = z.string().min(1);
+const timestampSchema = z.string().datetime({ offset: true });
+
+export const recoveryKnowledgeScopeSchema = z
+  .object({
+    tenantId: nonEmptyStringSchema.optional(),
+    userId: nonEmptyStringSchema,
+    workspaceId: nonEmptyStringSchema.optional(),
+    sessionId: nonEmptyStringSchema.optional(),
+    agentId: nonEmptyStringSchema.optional(),
+    domainPackId: nonEmptyStringSchema.optional(),
+  })
+  .strict() satisfies ZodType<RecoveryKnowledgeScope>;
+
+export const recoveryKnowledgeKeySchema = z
+  .object({
+    fingerprint: nonEmptyStringSchema,
+    participantId: nonEmptyStringSchema,
+    scope: recoveryKnowledgeScopeSchema.optional(),
+    policyRevision: nonEmptyStringSchema.optional(),
+    specRevision: nonEmptyStringSchema.optional(),
+    providerRevision: nonEmptyStringSchema.optional(),
+  })
+  .strict() satisfies ZodType<RecoveryKnowledgeKey>;
+
+export const scopedRecoveryKnowledgeKeySchema = recoveryKnowledgeKeySchema.extend({
+  scope: recoveryKnowledgeScopeSchema,
+});
+
+export const recoveryKnowledgeSchema = z
+  .object({
+    key: recoveryKnowledgeKeySchema,
+    strategy: z.enum(RECOVERY_STRATEGIES),
+    outcome: z.enum(['recovered', 'degraded', 'compensated', 'failed']),
+    evidenceHash: nonEmptyStringSchema,
+    learnedAt: timestampSchema,
+    expiresAt: timestampSchema.optional(),
+    validation: z
+      .object({
+        status: z.enum(['verified', 'negative']),
+        sourceEventId: nonEmptyStringSchema.optional(),
+        proof: z.record(z.unknown()).optional(),
+      })
+      .strict(),
+  })
+  .strict() satisfies ZodType<RecoveryKnowledge>;
+
+export const scopedRecoveryKnowledgeSchema = recoveryKnowledgeSchema.extend({
+  key: scopedRecoveryKnowledgeKeySchema,
+});
+
+const nonEmptyStringJsonSchema: JsonSchema = { type: 'string', minLength: 1 };
+
+export const recoveryKnowledgeScopeJsonSchema: JsonSchema = {
+  type: 'object',
+  required: ['userId'],
+  properties: {
+    tenantId: nonEmptyStringJsonSchema,
+    userId: nonEmptyStringJsonSchema,
+    workspaceId: nonEmptyStringJsonSchema,
+    sessionId: nonEmptyStringJsonSchema,
+    agentId: nonEmptyStringJsonSchema,
+    domainPackId: nonEmptyStringJsonSchema,
+  },
+  additionalProperties: false,
+};
+
+export const recoveryKnowledgeKeyJsonSchema: JsonSchema = {
+  type: 'object',
+  required: ['fingerprint', 'participantId'],
+  properties: {
+    fingerprint: nonEmptyStringJsonSchema,
+    participantId: nonEmptyStringJsonSchema,
+    scope: recoveryKnowledgeScopeJsonSchema,
+    policyRevision: nonEmptyStringJsonSchema,
+    specRevision: nonEmptyStringJsonSchema,
+    providerRevision: nonEmptyStringJsonSchema,
+  },
+  additionalProperties: false,
+};
+
+export const scopedRecoveryKnowledgeKeyJsonSchema: JsonSchema = {
+  ...recoveryKnowledgeKeyJsonSchema,
+  required: ['fingerprint', 'participantId', 'scope'],
+};
+
+export const recoveryKnowledgeJsonSchema: JsonSchema = {
+  type: 'object',
+  required: ['key', 'strategy', 'outcome', 'evidenceHash', 'learnedAt', 'validation'],
+  properties: {
+    key: recoveryKnowledgeKeyJsonSchema,
+    strategy: { type: 'string', enum: [...RECOVERY_STRATEGIES] },
+    outcome: { type: 'string', enum: ['recovered', 'degraded', 'compensated', 'failed'] },
+    evidenceHash: nonEmptyStringJsonSchema,
+    learnedAt: { type: 'string', format: 'date-time' },
+    expiresAt: { type: 'string', format: 'date-time' },
+    validation: {
+      type: 'object',
+      required: ['status'],
+      properties: {
+        status: { type: 'string', enum: ['verified', 'negative'] },
+        sourceEventId: nonEmptyStringJsonSchema,
+        proof: { type: 'object', additionalProperties: true },
+      },
+      additionalProperties: false,
+    },
+  },
+  additionalProperties: false,
+};
+
+export const scopedRecoveryKnowledgeJsonSchema: JsonSchema = {
+  ...recoveryKnowledgeJsonSchema,
+  properties: {
+    ...recoveryKnowledgeJsonSchema.properties,
+    key: scopedRecoveryKnowledgeKeyJsonSchema,
+  },
+};
+
+export function parseRecoveryKnowledge(input: unknown): RecoveryKnowledge {
+  return recoveryKnowledgeSchema.parse(input);
+}
+
+export function parseScopedRecoveryKnowledge(input: unknown): RecoveryKnowledge & {
+  key: RecoveryKnowledgeKey & { scope: RecoveryKnowledgeScope };
+} {
+  return scopedRecoveryKnowledgeSchema.parse(input);
+}

--- a/packages/core/src/contracts/recovery.test.ts
+++ b/packages/core/src/contracts/recovery.test.ts
@@ -5,6 +5,7 @@ import {
   recoveryKnowledgeKeyMatches,
   type RecoveryFailure,
 } from './recovery';
+import { parseScopedRecoveryKnowledge } from './recovery-knowledge-schemas';
 
 const failure: RecoveryFailure = {
   id: 'failure_1',
@@ -58,11 +59,38 @@ describe('@hypha/core recovery contracts', () => {
     const key = {
       fingerprint: recoveryFailureFingerprint(failure),
       participantId: 'memory-primary',
+      scope: { userId: 'user-1', sessionId: 'session-1' },
       policyRevision: 'policy-v1',
       specRevision: 'spec-v1',
       providerRevision: 'provider-v1',
     };
     expect(recoveryKnowledgeKeyMatches(key, { ...key })).toBe(true);
     expect(recoveryKnowledgeKeyMatches(key, { ...key, policyRevision: 'policy-v2' })).toBe(false);
+    expect(
+      recoveryKnowledgeKeyMatches(key, {
+        ...key,
+        scope: { ...key.scope, userId: 'user-2' },
+      })
+    ).toBe(false);
+  });
+
+  it('strictly validates scoped recovery knowledge before persistence', () => {
+    const item = {
+      key: {
+        fingerprint: recoveryFailureFingerprint(failure),
+        participantId: 'memory-primary',
+        scope: { userId: 'user-1', sessionId: 'session-1' },
+      },
+      strategy: 'retry',
+      outcome: 'recovered',
+      evidenceHash: 'evidence-1',
+      learnedAt: '2026-07-21T00:00:00.000Z',
+      validation: { status: 'verified' },
+    };
+    expect(parseScopedRecoveryKnowledge(item)).toEqual(item);
+    expect(() =>
+      parseScopedRecoveryKnowledge({ ...item, key: { ...item.key, scope: undefined } })
+    ).toThrow();
+    expect(() => parseScopedRecoveryKnowledge({ ...item, unexpected: true })).toThrow();
   });
 });

--- a/packages/core/src/contracts/recovery.ts
+++ b/packages/core/src/contracts/recovery.ts
@@ -157,9 +157,23 @@ export const defaultRecoveryConvergencePolicy: RecoveryConvergencePolicy = {
   onExhausted: 'human_review',
 };
 
+export interface RecoveryKnowledgeScope {
+  tenantId?: string;
+  userId: string;
+  workspaceId?: string;
+  sessionId?: string;
+  agentId?: string;
+  domainPackId?: string;
+}
+
 export interface RecoveryKnowledgeKey {
   fingerprint: string;
   participantId: string;
+  /**
+   * New runtime writes always include scope. Absence is accepted only for
+   * legacy Provider migration and must not be persisted by strict adapters.
+   */
+  scope?: RecoveryKnowledgeScope;
   policyRevision?: string;
   specRevision?: string;
   providerRevision?: string;
@@ -215,9 +229,25 @@ export function recoveryKnowledgeKeyMatches(
   return (
     expected.fingerprint === actual.fingerprint &&
     expected.participantId === actual.participantId &&
+    recoveryKnowledgeScopeMatches(expected.scope, actual.scope) &&
     expected.policyRevision === actual.policyRevision &&
     expected.specRevision === actual.specRevision &&
     expected.providerRevision === actual.providerRevision
+  );
+}
+
+export function recoveryKnowledgeScopeMatches(
+  expected: RecoveryKnowledgeScope | undefined,
+  actual: RecoveryKnowledgeScope | undefined
+): boolean {
+  if (!expected || !actual) return expected === actual;
+  return (
+    expected.tenantId === actual.tenantId &&
+    expected.userId === actual.userId &&
+    expected.workspaceId === actual.workspaceId &&
+    expected.sessionId === actual.sessionId &&
+    expected.agentId === actual.agentId &&
+    expected.domainPackId === actual.domainPackId
   );
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export * from './contracts/execution-governance';
 export * from './contracts/execution-output';
 export * from './contracts/execution-port';
 export * from './contracts/recovery';
+export * from './contracts/recovery-knowledge-schemas';
 export * from './contracts/workspace';
 export * from './contracts/sandbox';
 export * from './contracts/runtime';

--- a/packages/harness/src/recovery-supervisor.test.ts
+++ b/packages/harness/src/recovery-supervisor.test.ts
@@ -71,6 +71,7 @@ describe('@hypha/harness coordinated recovery supervisor', () => {
     const result = await runRecoverySupervisor({
       fsm,
       caseId: 'case_memory_execution',
+      userId: 'user-recovery',
       trace,
       now: () => '2026-07-16T00:00:00.100Z',
       policy: { maxNoProgressCycles: 1 },
@@ -107,6 +108,7 @@ describe('@hypha/harness coordinated recovery supervisor', () => {
     });
     expect(memoryExecute).toHaveBeenCalledTimes(2);
     expect(execution).toHaveBeenCalledOnce();
+    expect(execution.mock.calls[0]?.[0].scope).toEqual({ userId: 'user-recovery' });
     expect(result.snapshot).toMatchObject({
       status: 'degraded',
       noProgressCycles: 1,
@@ -123,6 +125,9 @@ describe('@hypha/harness coordinated recovery supervisor', () => {
       expect.arrayContaining([
         expect.objectContaining({
           knowledge: expect.objectContaining({
+            key: expect.objectContaining({
+              scope: expect.objectContaining({ userId: 'user-recovery' }),
+            }),
             strategy: 'degrade',
             outcome: 'degraded',
             validation: { status: 'verified' },
@@ -151,6 +156,7 @@ describe('@hypha/harness coordinated recovery supervisor', () => {
     const result = await runRecoverySupervisor({
       fsm,
       caseId: 'case_unknown_execution',
+      userId: 'user-recovery',
       now: () => '2026-07-16T00:00:00.100Z',
       participants: [
         {

--- a/packages/harness/src/recovery-supervisor.ts
+++ b/packages/harness/src/recovery-supervisor.ts
@@ -13,6 +13,7 @@ import {
   type RecoveryKnowledge,
   type RecoveryKnowledgeKey,
   type RecoveryKnowledgePort,
+  type RecoveryKnowledgeScope,
   type RecoveryModule,
   type RecoveryStrategy,
   type TraceRecorder,
@@ -28,6 +29,7 @@ export interface RecoveryParticipantResult<TOutput = unknown> {
 export interface RecoveryParticipantContext {
   caseId: string;
   runId: string;
+  scope: RecoveryKnowledgeScope;
   participantId: string;
   module: RecoveryModule;
   cycle: number;
@@ -63,6 +65,8 @@ export interface RecoverySupervisorScheduler {
 export interface RecoverySupervisorOptions {
   fsm: FSMRuntime;
   caseId: string;
+  userId: string;
+  tenantId?: string;
   participants: RecoveryParticipant[];
   policy?: Partial<RecoveryConvergencePolicy>;
   knowledge?: RecoveryKnowledgePort;
@@ -71,6 +75,7 @@ export interface RecoverySupervisorOptions {
   workspaceId?: string;
   stepId?: string;
   agentId?: string;
+  domainPackId?: string;
   scheduler?: RecoverySupervisorScheduler;
   maxInlineDelayMs?: number;
   signal?: AbortSignal;
@@ -108,6 +113,7 @@ export async function runRecoverySupervisor(
   };
   const now = options.now ?? (() => new Date().toISOString());
   const runId = options.fsm.getSnapshot().runId;
+  const knowledgeScope = recoveryKnowledgeScope(options);
   const outputs: Record<string, unknown> = {};
   const completed = new Set<string>();
   const recorder = new RecoveryEventRecorder(options, runId, now);
@@ -157,6 +163,7 @@ export async function runRecoverySupervisor(
               'retry',
               'recovered',
               pendingRetry.evidenceAfterHash ?? recoveryEvidenceHash(result.evidence),
+              knowledgeScope,
               now()
             );
             await recorder.record('recovery.attempt.completed', snapshot, {
@@ -191,6 +198,7 @@ export async function runRecoverySupervisor(
             'retry',
             'failed',
             pendingRetry.evidenceAfterHash ?? recoveryEvidenceHash(failure.evidence),
+            knowledgeScope,
             now()
           );
           await recorder.record('recovery.attempt.completed', snapshot, {
@@ -229,6 +237,7 @@ export async function runRecoverySupervisor(
           fsmDecision,
           policy,
           options.knowledge,
+          knowledgeScope,
           now()
         );
         await recorder.record('recovery.strategy.selected', snapshot, {
@@ -336,6 +345,7 @@ export async function runRecoverySupervisor(
                 ? 'compensated'
                 : 'recovered',
             snapshot.lastEvidenceHash,
+            knowledgeScope,
             now()
           );
           await recorder.record('recovery.attempt.completed', snapshot, {
@@ -367,6 +377,7 @@ export async function runRecoverySupervisor(
             action,
             'failed',
             snapshot.lastEvidenceHash,
+            knowledgeScope,
             now()
           );
           await recorder.record('recovery.attempt.completed', snapshot, {
@@ -431,6 +442,7 @@ async function selectStrategy(
   decision: FSMRecoveryDecision,
   policy: RecoveryConvergencePolicy,
   knowledge: RecoveryKnowledgePort | undefined,
+  scope: RecoveryKnowledgeScope,
   now: string
 ): Promise<RecoveryStrategy> {
   const repeatedStrategy = snapshot.attempts.filter(
@@ -448,7 +460,7 @@ async function selectStrategy(
     return availableEscalation(policy.onNoProgress, participant);
   }
 
-  const key = knowledgeKey(participant, failure);
+  const key = knowledgeKey(participant, failure, scope);
   const hint = await knowledge?.get(key);
   if (hint) {
     const validTime = !hint.expiresAt || Date.parse(hint.expiresAt) > Date.parse(now);
@@ -543,10 +555,11 @@ async function rememberOutcome(
   strategy: RecoveryStrategy,
   outcome: RecoveryKnowledge['outcome'],
   evidenceHash: string,
+  scope: RecoveryKnowledgeScope,
   now: string
 ): Promise<RecoveryKnowledge> {
   const item: RecoveryKnowledge = {
-    key: knowledgeKey(participant, failure),
+    key: knowledgeKey(participant, failure, scope),
     strategy,
     outcome,
     evidenceHash,
@@ -559,14 +572,29 @@ async function rememberOutcome(
 
 function knowledgeKey(
   participant: RecoveryParticipant,
-  failure: RecoveryFailure
+  failure: RecoveryFailure,
+  scope: RecoveryKnowledgeScope
 ): RecoveryKnowledgeKey {
   return {
     fingerprint: recoveryFailureFingerprint(failure),
     participantId: participant.id,
+    scope,
     policyRevision: failure.evidence.policyRevision,
     specRevision: failure.evidence.specRevision,
     providerRevision: failure.evidence.providerRevision,
+  };
+}
+
+function recoveryKnowledgeScope(options: RecoverySupervisorOptions): RecoveryKnowledgeScope {
+  const userId = options.userId.trim();
+  if (!userId) throw new Error('Recovery supervisor requires a non-empty userId.');
+  return {
+    userId,
+    ...(options.tenantId ? { tenantId: options.tenantId } : {}),
+    ...(options.workspaceId ? { workspaceId: options.workspaceId } : {}),
+    ...(options.sessionId ? { sessionId: options.sessionId } : {}),
+    ...(options.agentId ? { agentId: options.agentId } : {}),
+    ...(options.domainPackId ? { domainPackId: options.domainPackId } : {}),
   };
 }
 
@@ -684,6 +712,7 @@ function participantContext(
   return {
     caseId: options.caseId,
     runId: options.fsm.getSnapshot().runId,
+    scope: recoveryKnowledgeScope(options),
     participantId: participant.id,
     module: participant.module,
     cycle,


### PR DESCRIPTION
## 变更目标

修复 Runtime Recovery Knowledge 在 Cache Provider 中缺少用户硬边界的问题，并补齐可运行时校验的契约。

## 主要实现

- 新增 `RecoveryKnowledgeScope`，覆盖 tenant、user、workspace、session、agent、DomainPack。
- Recovery Supervisor 强制非空 `userId`，知识查询、写入、参与者上下文和事件证据使用同一 scope。
- Key matching 同时比较作用域与 policy/spec/provider revisions，跨用户提示不能命中。
- 新增 strict Zod Schema、JSON Schema 和解析 API；未知字段与缺少 scope 的持久化输入可被拒绝。
- 旧无 scope key 仅保留 Provider 迁移类型兼容；框架新写入始终 scoped。
- EventRuntime 从真实 RunContext 注入 inference cache scope 与 recovery knowledge scope。

## 验证

- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test:unit`（65/65）
- `npm run test:packages`（136 suites / 1033 tests）
- Core/Harness focused tests（6/6）
- `git diff --check`

## 所有权说明

变更限于 Runtime/Core/Harness 契约及必要的 server runtime wiring。WorkCache Provider 的 strict persistence 门禁将在 Cache Owner feature branch 中适配后合入 `cache-base`。
