### PR TITLE
fix(cache): enforce scoped recovery knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ reconciliation, compatible fallback, degradation, compensation, human review, qu
 cancellation, and failure are explicit strategies with trace events.
 
 Unknown write outcomes are reconciled before replay. Optional caches may be bypassed without
-changing the source result, and WorkCache can retain only revision-matched, revalidated recovery
-knowledge as an acceleration hint. The event log and FSM snapshot remain the sources of truth. See
+changing the source result, and WorkCache can retain only user-scoped, revision-matched, revalidated
+recovery knowledge as an acceleration hint. The event log and FSM snapshot remain the sources of truth. See
 [FSM anomaly recovery](docs/architecture/fsm-recovery.md).
 
 ## Inference Runtime
 
-Agent inference is exposed through `@hypha/inference`: prompt compilation, prefix segmentation, Plasmod cache coordination, backend routing, and normalized responses. SGLang is the default physical backend, with vLLM, llama.cpp, and OpenAI API adapters available through the same backend registry.
+Agent inference is exposed through `@hypha/inference`: prompt compilation, prefix segmentation, user-scoped and bounded Plasmod cache coordination, backend routing, and normalized responses. SGLang is the default physical backend, with vLLM, llama.cpp, and OpenAI API adapters available through the same backend registry.
 
 Configure the default backend and endpoints in `config.yaml` or `.env`, for example `HYPHA_INFERENCE_DEFAULT_BACKEND=sglang` and `SGLANG_BASE_URL=http://localhost:30000`.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -68,11 +68,11 @@ Event 与 checkpoint 证据防止 stale worker 或重复循环被误判为有效
 
 Hypha 使用同一套 FSM 恢复契约协调 inference、tool、MCP、memory、execution、storage、消息投递、policy 与 cache 异常。参与模块按依赖顺序执行，已经完成的上游不会重复运行；系统通过稳定的 receipt、revision、hash 或 provider state 判断是否真正取得进展，而不是把再次循环视为进展。有界重试、对账、兼容 fallback、降级、补偿、人工复核、隔离、取消和失败都具有显式策略与 trace event。
 
-写入结果不确定时必须先对账再决定是否重放。可选 cache 失败时可以 bypass，但不能改变源操作结果；WorkCache 只保存与 policy/spec/provider revision 匹配并重新校验过的恢复知识，用作加速提示。Event log 与 FSM snapshot 始终是真相源。详见 [FSM 异常恢复](docs/architecture/fsm-recovery.md)。
+写入结果不确定时必须先对账再决定是否重放。可选 cache 失败时可以 bypass，但不能改变源操作结果；WorkCache 只保存具有用户作用域、与 policy/spec/provider revision 匹配并重新校验过的恢复知识，用作加速提示。Event log 与 FSM snapshot 始终是真相源。详见 [FSM 异常恢复](docs/architecture/fsm-recovery.md)。
 
 ## Inference Runtime
 
-Agent inference 由 `@hypha/inference` 提供：prompt 编译、prefix 分段、Plasmod cache 协调、backend 路由和统一响应。默认物理 backend 是 SGLang，同时通过同一套 backend registry 支持 vLLM、llama.cpp 和 OpenAI API。
+Agent inference 由 `@hypha/inference` 提供：prompt 编译、prefix 分段、具备用户作用域与容量边界的 Plasmod cache 协调、backend 路由和统一响应。默认物理 backend 是 SGLang，同时通过同一套 backend registry 支持 vLLM、llama.cpp 和 OpenAI API。
 
 默认 backend 与 endpoint 在 `config.yaml` 或 `.env` 中配置，例如 `HYPHA_INFERENCE_DEFAULT_BACKEND=sglang` 和 `SGLANG_BASE_URL=http://localhost:30000`。
 

--- a/docs/api/framework.md
+++ b/docs/api/framework.md
@@ -420,7 +420,7 @@ Core exports:
 | `SQLiteWorkCacheStore`            | Bounded persistent store backed by `workcache_blocks`.                                          |
 | `RedisWorkCacheStore`             | Shared, TTL-aware store with atomic latest-key maintenance.                                     |
 | `TimeoutWorkCacheStore`           | Bounds provider-neutral store calls.                                                            |
-| `RedisWorkCacheInvalidationBus`   | Propagates invalidation to peer hot indexes.                                                     |
+| `RedisWorkCacheInvalidationBus`   | Propagates invalidation to peer hot indexes.                                                    |
 
 Default source event alignment:
 
@@ -453,10 +453,12 @@ Derived audit events are `workcache.lookup`, `workcache.hit`,
 `workcache.bypass`, and `workcache.prefix.materialized`. Each payload includes
 `sourceEventId`, `sourceEventType`, `treeType`, `blockId`, and `cacheKey`.
 
-`WorkCacheManager.getRecoveryKnowledgePort()` exposes recovery strategy hints keyed by failure
-fingerprint, participant, and policy/spec/provider revision. Values include strategy, outcome,
-evidence hash, expiry, and verified/negative validation. Expired or mismatched blocks are removed;
-the runtime supervisor revalidates hits and remains the only component that advances the FSM case.
+`WorkCacheManager.getRecoveryKnowledgePort()` exposes recovery strategy hints keyed by structured
+tenant/user/workspace/session/agent/DomainPack scope, failure fingerprint, participant, and
+policy/spec/provider revision. Core exports strict Zod and JSON Schemas for scoped recovery
+knowledge. Values include strategy, outcome, evidence hash, expiry, and verified/negative
+validation. Unscoped, malformed, expired, or mismatched blocks are rejected or removed; the runtime
+supervisor revalidates hits and remains the only component that advances the FSM case.
 
 ## Inference
 

--- a/docs/architecture/workcache.md
+++ b/docs/architecture/workcache.md
@@ -119,13 +119,14 @@ ordering/template metadata. Dynamic suffix hashes and request ids are trace
 metadata only; they do not invalidate stable prefix blocks. A template content
 or version change should produce a new block hash and therefore a new block.
 
-Recovery knowledge is keyed by failure fingerprint, participant id, and
-policy/spec/provider revisions. `WorkCacheManager.getRecoveryKnowledgePort()`
-stores verified and negative outcomes with an evidence hash and TTL. Lookup
-removes expired entries; a new revision removes stale entries for the same
-failure and participant. The recovery supervisor still revalidates every hit
-and uses only a verified strategy for a handler declared by the current
-participant. Negative knowledge records a failed strategy but does not
+Recovery knowledge is keyed by tenant/user/workspace/session/agent/DomainPack
+scope, failure fingerprint, participant id, and policy/spec/provider revisions.
+`WorkCacheManager.getRecoveryKnowledgePort()` validates scoped knowledge with
+the Core runtime schema before persistence and removes malformed legacy blocks.
+A new revision removes stale entries only inside the same scope; invalidation
+cannot remove another user's hint. The recovery supervisor still revalidates
+every hit and uses only a verified strategy for a handler declared by the
+current participant. Negative knowledge records a failed strategy but does not
 authorize a different side effect. Store outages bypass recovery hints rather
 than interrupting the recovery supervisor.
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -151,9 +151,11 @@ agent interfaces, and does not implement MessageTree or KVPrefixTree in V1.
 
 `RecoveryTree` is the recovery-specific cache boundary. It consumes completed/resolved/escalated
 recovery events and exposes a `RecoveryKnowledgePort` through `WorkCacheManager`. Keys include the
-failure fingerprint, participant, and policy/spec/provider revisions; expiry or revision drift
-deletes stale blocks. A hit is a revalidated strategy hint only—the FSM snapshot, events, and
-provider receipts still determine whether recovery succeeded.
+tenant/user/workspace/session/agent/DomainPack scope, failure fingerprint, participant, and
+policy/spec/provider revisions. Strict runtime validation rejects unscoped or malformed persisted
+hints; expiry or revision drift deletes stale blocks only inside the same scope. A hit is a
+revalidated strategy hint only—the FSM snapshot, events, and provider receipts still determine
+whether recovery succeeded.
 
 ## Extension Boundaries
 

--- a/packages/workcache/src/materializers.ts
+++ b/packages/workcache/src/materializers.ts
@@ -1,4 +1,8 @@
-import type { FrameworkEvent, RecoveryKnowledge } from '@hypha/core';
+import {
+  parseScopedRecoveryKnowledge,
+  type FrameworkEvent,
+  type RecoveryKnowledge,
+} from '@hypha/core';
 import { createWorkBlockId, createWorkCacheKey, hashStableJson, stableJson } from './key';
 import type {
   CacheBlock,
@@ -290,31 +294,28 @@ export function materializeMessageBlock(event: NormalizedWorkEvent): CacheBlock[
 
 export function materializeRecoveryKnowledgeBlock(event: NormalizedWorkEvent): CacheBlock[] {
   const payload = recordFromUnknown(event.payload);
-  const rawKnowledge = recordFromUnknown(payload.knowledge);
-  const rawKey = recordFromUnknown(rawKnowledge.key);
-  const validation = recordFromUnknown(rawKnowledge.validation);
-  const fingerprint = stringValue(rawKey.fingerprint);
-  const participantId = stringValue(rawKey.participantId);
-  const strategy = stringValue(rawKnowledge.strategy);
-  const outcome = stringValue(rawKnowledge.outcome);
-  const learnedAt = stringValue(rawKnowledge.learnedAt);
-  const validationStatus = stringValue(validation.status);
+  let knowledge: RecoveryKnowledge;
+  try {
+    knowledge = parseScopedRecoveryKnowledge(payload.knowledge);
+  } catch {
+    return [];
+  }
   if (
-    !fingerprint ||
-    !participantId ||
-    !strategy ||
-    !outcome ||
-    !learnedAt ||
-    (validationStatus !== 'verified' && validationStatus !== 'negative')
+    (event.sourceEvent.userId && knowledge.key.scope?.userId !== event.sourceEvent.userId) ||
+    (event.sourceEvent.sessionId &&
+      knowledge.key.scope?.sessionId &&
+      knowledge.key.scope.sessionId !== event.sourceEvent.sessionId)
   ) {
     return [];
   }
-  const knowledge = rawKnowledge as unknown as RecoveryKnowledge;
+  const { fingerprint, participantId } = knowledge.key;
+  const { strategy, outcome, learnedAt, validation } = knowledge;
+  const validationStatus = validation.status;
   const sourceHashes = Object.fromEntries(
     [
-      ['policy', stringValue(rawKey.policyRevision)],
-      ['spec', stringValue(rawKey.specRevision)],
-      ['provider', stringValue(rawKey.providerRevision)],
+      ['policy', knowledge.key.policyRevision],
+      ['spec', knowledge.key.specRevision],
+      ['provider', knowledge.key.providerRevision],
     ].filter((entry): entry is [string, string] => Boolean(entry[1]))
   );
   return [
@@ -323,7 +324,7 @@ export function materializeRecoveryKnowledgeBlock(event: NormalizedWorkEvent): C
       value: knowledge,
       validity: {
         status: 'valid',
-        proof: recordFromUnknown(validation.proof),
+        proof: validation.proof,
         sourceHashes,
         provenanceHash: hashStableJson({ key: knowledge.key, validation }),
       },

--- a/packages/workcache/src/recovery-knowledge.test.ts
+++ b/packages/workcache/src/recovery-knowledge.test.ts
@@ -9,6 +9,7 @@ function knowledge(overrides: Partial<RecoveryKnowledge> = {}): RecoveryKnowledg
     key: {
       fingerprint: 'failure-fingerprint',
       participantId: 'memory-primary',
+      scope: { userId: 'owner', sessionId: 'session-recovery' },
       policyRevision: 'policy-v1',
       specRevision: 'spec-v1',
       providerRevision: 'provider-v1',
@@ -65,6 +66,45 @@ describe('@hypha/workcache recovery knowledge', () => {
     await expect(store.list('RecoveryTree')).resolves.toHaveLength(0);
   });
 
+  it('never removes or reuses recovery knowledge across user scopes', async () => {
+    const store = new MemoryWorkCacheStore();
+    const recovery = new WorkCacheRecoveryKnowledgeStore(store);
+    const owner = knowledge();
+    const collaborator = knowledge({
+      key: { ...owner.key, scope: { userId: 'collaborator' } },
+      learnedAt: '2026-07-16T00:01:00.000Z',
+    });
+    await recovery.put(owner);
+    await recovery.put(collaborator);
+
+    await expect(recovery.get(owner.key)).resolves.toEqual(owner);
+    await expect(recovery.get(collaborator.key)).resolves.toEqual(collaborator);
+    await recovery.invalidate(owner.key, 'owner-only');
+    await expect(recovery.get(owner.key)).resolves.toBeNull();
+    await expect(recovery.get(collaborator.key)).resolves.toEqual(collaborator);
+  });
+
+  it('rejects unscoped and malformed knowledge before it can be reused', async () => {
+    const store = new MemoryWorkCacheStore();
+    const bypass = new WorkCacheRecoveryKnowledgeStore(store);
+    const unscoped = knowledge({ key: { ...knowledge().key, scope: undefined } });
+    await expect(bypass.put(unscoped)).resolves.toBeUndefined();
+    await expect(store.list('RecoveryTree')).resolves.toHaveLength(0);
+
+    const valid = knowledge();
+    await bypass.put(valid);
+    const [block] = await store.list<RecoveryKnowledge>('RecoveryTree');
+    await store.set({
+      ...block,
+      value: { ...block.value, unexpected: true } as RecoveryKnowledge,
+    });
+    await expect(bypass.get(valid.key)).resolves.toBeNull();
+    await expect(store.list('RecoveryTree')).resolves.toHaveLength(0);
+
+    const strict = new WorkCacheRecoveryKnowledgeStore(store, { failureMode: 'strict' });
+    await expect(strict.put(unscoped)).rejects.toThrow();
+  });
+
   it('exposes a shared manager port and materializes event-backed recovery knowledge', async () => {
     const store = new MemoryWorkCacheStore();
     const manager = new WorkCacheManager({
@@ -98,6 +138,26 @@ describe('@hypha/workcache recovery knowledge', () => {
     expect(blocks.map((block) => block.value.key.participantId)).toEqual(
       expect.arrayContaining(['memory-primary', 'execution-primary'])
     );
+
+    const spoofed = knowledge({
+      key: {
+        ...item.key,
+        participantId: 'spoofed-primary',
+        scope: { userId: 'collaborator' },
+      },
+    });
+    const spoofedAudit = await manager.ingest(
+      createFrameworkEvent({
+        id: 'recovery-attempt-spoofed',
+        type: 'recovery.attempt.completed',
+        runId: 'run_recovery_cache',
+        userId: 'owner',
+        timestamp: '2026-07-16T00:00:01.000Z',
+        payload: { knowledge: spoofed },
+      })
+    );
+    expect(spoofedAudit.map((event) => event.type)).not.toContain('workcache.write');
+    await expect(manager.forest.list<RecoveryKnowledge>('RecoveryTree')).resolves.toHaveLength(2);
   });
 
   it('keeps optional recovery hints fail-open when the cache store is unavailable', async () => {

--- a/packages/workcache/src/recovery-knowledge.ts
+++ b/packages/workcache/src/recovery-knowledge.ts
@@ -1,5 +1,10 @@
 import {
+  parseRecoveryKnowledge,
+  parseScopedRecoveryKnowledge,
+  recoveryKnowledgeKeySchema,
   recoveryKnowledgeKeyMatches,
+  recoveryKnowledgeScopeMatches,
+  scopedRecoveryKnowledgeKeySchema,
   type RecoveryKnowledge,
   type RecoveryKnowledgeKey,
   type RecoveryKnowledgePort,
@@ -12,6 +17,7 @@ export interface WorkCacheRecoveryKnowledgeOptions {
   now?: () => number;
   failureMode?: 'bypass' | 'strict';
   maxEntries?: number;
+  requireUserScope?: boolean;
 }
 
 export class WorkCacheRecoveryKnowledgeStore implements RecoveryKnowledgePort {
@@ -19,6 +25,7 @@ export class WorkCacheRecoveryKnowledgeStore implements RecoveryKnowledgePort {
   private readonly now: () => number;
   private readonly failureMode: 'bypass' | 'strict';
   private readonly maxEntries: number;
+  private readonly requireUserScope: boolean;
 
   constructor(
     private readonly store: WorkCacheStore,
@@ -28,11 +35,12 @@ export class WorkCacheRecoveryKnowledgeStore implements RecoveryKnowledgePort {
     this.now = options.now ?? Date.now;
     this.failureMode = options.failureMode ?? 'bypass';
     this.maxEntries = Math.max(1, options.maxEntries ?? 1000);
+    this.requireUserScope = options.requireUserScope ?? true;
   }
 
   async get(key: RecoveryKnowledgeKey): Promise<RecoveryKnowledge | null> {
     try {
-      return await this.getInternal(key);
+      return await this.getInternal(this.validateKey(key));
     } catch (error) {
       if (this.failureMode === 'strict') throw error;
       return null;
@@ -45,26 +53,34 @@ export class WorkCacheRecoveryKnowledgeStore implements RecoveryKnowledgePort {
       recoveryKnowledgeCacheKey(key)
     );
     if (!block) return null;
+    let knowledge: RecoveryKnowledge;
+    try {
+      knowledge = this.validateKnowledge(block.value);
+    } catch (error) {
+      await this.store.delete(block.id);
+      throw error;
+    }
     if (
       block.validity.status !== 'valid' ||
       (block.expiresAt !== undefined && block.expiresAt <= this.now()) ||
-      (block.value.expiresAt !== undefined && Date.parse(block.value.expiresAt) <= this.now())
+      (knowledge.expiresAt !== undefined && Date.parse(knowledge.expiresAt) <= this.now())
     ) {
       await this.store.delete(block.id);
       return null;
     }
-    if (!recoveryKnowledgeKeyMatches(key, block.value.key)) {
+    if (!recoveryKnowledgeKeyMatches(key, knowledge.key)) {
       await this.store.delete(block.id);
       return null;
     }
     await this.store.touch?.(block.id, this.now());
-    return block.value;
+    return knowledge;
   }
 
   async put(knowledge: RecoveryKnowledge): Promise<void> {
     try {
-      await this.removeStaleRevisions(knowledge.key);
-      await this.store.set(this.blockFromKnowledge(knowledge));
+      const validated = this.validateKnowledge(knowledge);
+      await this.removeStaleRevisions(validated.key);
+      await this.store.set(this.blockFromKnowledge(validated));
       await this.prune();
     } catch (error) {
       if (this.failureMode === 'strict') throw error;
@@ -73,14 +89,11 @@ export class WorkCacheRecoveryKnowledgeStore implements RecoveryKnowledgePort {
 
   async invalidate(key: RecoveryKnowledgeKey, _reason: string): Promise<void> {
     try {
-      const blocks = await this.store.list<RecoveryKnowledgeBlockValue>('RecoveryTree');
+      const validatedKey = this.validateKey(key);
+      const blocks = await this.listValidatedBlocks();
       await Promise.all(
         blocks
-          .filter(
-            (block) =>
-              block.value.key.fingerprint === key.fingerprint &&
-              block.value.key.participantId === key.participantId
-          )
+          .filter((block) => sameRecoveryKnowledgeIdentity(block.value.key, validatedKey))
           .map((block) => this.store.delete(block.id))
       );
     } catch (error) {
@@ -89,13 +102,12 @@ export class WorkCacheRecoveryKnowledgeStore implements RecoveryKnowledgePort {
   }
 
   private async removeStaleRevisions(key: RecoveryKnowledgeKey): Promise<void> {
-    const blocks = await this.store.list<RecoveryKnowledgeBlockValue>('RecoveryTree');
+    const blocks = await this.listValidatedBlocks();
     await Promise.all(
       blocks
         .filter(
           (block) =>
-            block.value.key.fingerprint === key.fingerprint &&
-            block.value.key.participantId === key.participantId &&
+            sameRecoveryKnowledgeIdentity(block.value.key, key) &&
             !recoveryKnowledgeKeyMatches(key, block.value.key)
         )
         .map((block) => this.store.delete(block.id))
@@ -103,11 +115,37 @@ export class WorkCacheRecoveryKnowledgeStore implements RecoveryKnowledgePort {
   }
 
   private async prune(): Promise<void> {
-    const blocks = await this.store.list<RecoveryKnowledgeBlockValue>('RecoveryTree');
+    const blocks = await this.listValidatedBlocks();
     const excess = blocks
       .sort((left, right) => left.updatedAt - right.updatedAt)
       .slice(0, Math.max(0, blocks.length - this.maxEntries));
     await Promise.all(excess.map((block) => this.store.delete(block.id)));
+  }
+
+  private async listValidatedBlocks(): Promise<CacheBlock<RecoveryKnowledgeBlockValue>[]> {
+    const blocks = await this.store.list<RecoveryKnowledgeBlockValue>('RecoveryTree');
+    const valid: CacheBlock<RecoveryKnowledgeBlockValue>[] = [];
+    for (const block of blocks) {
+      try {
+        valid.push({ ...block, value: this.validateKnowledge(block.value) });
+      } catch (error) {
+        await this.store.delete(block.id);
+        if (this.failureMode === 'strict') throw error;
+      }
+    }
+    return valid;
+  }
+
+  private validateKey(key: RecoveryKnowledgeKey): RecoveryKnowledgeKey {
+    return this.requireUserScope
+      ? scopedRecoveryKnowledgeKeySchema.parse(key)
+      : recoveryKnowledgeKeySchema.parse(key);
+  }
+
+  private validateKnowledge(knowledge: RecoveryKnowledge): RecoveryKnowledge {
+    return this.requireUserScope
+      ? parseScopedRecoveryKnowledge(knowledge)
+      : parseRecoveryKnowledge(knowledge);
   }
 
   private blockFromKnowledge(
@@ -167,4 +205,15 @@ export class WorkCacheRecoveryKnowledgeStore implements RecoveryKnowledgePort {
 
 export function recoveryKnowledgeCacheKey(key: RecoveryKnowledgeKey): string {
   return `workcache:RecoveryTree:recovery:sha256:${hashStableJson(key)}`;
+}
+
+function sameRecoveryKnowledgeIdentity(
+  left: RecoveryKnowledgeKey,
+  right: RecoveryKnowledgeKey
+): boolean {
+  return (
+    left.fingerprint === right.fingerprint &&
+    left.participantId === right.participantId &&
+    recoveryKnowledgeScopeMatches(left.scope, right.scope)
+  );
 }


### PR DESCRIPTION
## 变更目标

完成 Runtime scoped recovery contract 在 WorkCache/RecoveryTree Provider 中的严格持久化适配。

## 主要实现

- RecoveryTree 默认要求非空用户作用域，并在读写前执行 Core strict schema 校验。
- 无 scope、未知字段、损坏或过期的持久化 hint 不会命中；损坏块会删除，strict 模式显式失败。
- revision 淘汰和主动 invalidation 仅作用于相同 tenant/user/workspace/session/agent/DomainPack scope。
- Event materializer 拒绝 knowledge scope 与 source event user/session 不一致的伪造载荷。
- 保留 `requireUserScope: false` 作为显式迁移兼容开关，默认路径始终安全。
- 更新公开 WorkCache、API、架构和 README 能力说明。

## 验证

- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test:unit`（73/73）
- `npm run test:packages`（140 suites / 1093 tests）
- `npm run test:integration`（29/29，真实 MongoDB + Redis）
- Recovery/Hardening focused tests（14/14）
- `git diff --check`

## 所有权说明

变更从 Cache Owner feature branch 合入 `cache-base`；Core/Runtime 契约已经通过 `runtime → dev → cache-base` 正向同步。
