### PR TITLE
fix(inference): time-bound cache providers

### DIFF
--- a/packages/inference/src/cache.ts
+++ b/packages/inference/src/cache.ts
@@ -31,13 +31,35 @@ export interface InferenceCacheManagerOptions {
   prefixCache: PrefixCacheProvider;
   kvCache: KvCacheProvider;
   now?: () => Date;
+  operationTimeoutMs?: number;
+}
+
+export type InferenceCacheOperation =
+  | 'prefix_read'
+  | 'prefix_write'
+  | 'kv_read'
+  | 'kv_write'
+  | 'invalidate';
+
+export class InferenceCacheOperationTimeoutError extends Error {
+  readonly code = 'INFERENCE_CACHE_OPERATION_TIMEOUT';
+
+  constructor(
+    readonly operation: InferenceCacheOperation,
+    readonly timeoutMs: number
+  ) {
+    super(`Inference cache ${operation} timed out after ${timeoutMs}ms.`);
+    this.name = 'InferenceCacheOperationTimeoutError';
+  }
 }
 
 export class InferenceCacheManager {
   private readonly now: () => Date;
+  private readonly operationTimeoutMs: number;
 
   constructor(private readonly options: InferenceCacheManagerOptions) {
     this.now = options.now ?? (() => new Date());
+    this.operationTimeoutMs = Math.max(1, options.operationTimeoutMs ?? 1_000);
   }
 
   async putPrefix(input: PrefixCacheCreateInput): Promise<PrefixCacheRef> {
@@ -49,12 +71,20 @@ export class InferenceCacheManager {
       cacheScope: input.cacheScope,
       metadata: input.metadata,
     };
-    await this.options.prefixCache.put(ref, input.content);
+    await runInferenceCacheOperation(
+      'prefix_write',
+      () => this.options.prefixCache.put(ref, input.content),
+      this.operationTimeoutMs
+    );
     return ref;
   }
 
   async getPrefix(ref: PrefixCacheRef): Promise<string | null> {
-    return this.options.prefixCache.get(ref);
+    return runInferenceCacheOperation(
+      'prefix_read',
+      () => this.options.prefixCache.get(ref),
+      this.operationTimeoutMs
+    );
   }
 
   async putKv(input: KvCacheCreateInput, value: unknown): Promise<KvCacheRef> {
@@ -71,16 +101,28 @@ export class InferenceCacheManager {
       expiresAt,
       metadata: input.metadata,
     };
-    await this.options.kvCache.put(ref, value);
+    await runInferenceCacheOperation(
+      'kv_write',
+      () => this.options.kvCache.put(ref, value),
+      this.operationTimeoutMs
+    );
     return ref;
   }
 
   async getKv(ref: KvCacheRef): Promise<unknown | null> {
     if (isKvCacheExpired(ref, this.now())) {
-      await this.options.kvCache.invalidate(ref, 'expired');
+      await runInferenceCacheOperation(
+        'invalidate',
+        () => this.options.kvCache.invalidate(ref, 'expired'),
+        this.operationTimeoutMs
+      );
       return null;
     }
-    return this.options.kvCache.get(ref);
+    return runInferenceCacheOperation(
+      'kv_read',
+      () => this.options.kvCache.get(ref),
+      this.operationTimeoutMs
+    );
   }
 }
 
@@ -93,6 +135,27 @@ export function inferenceCacheScopeHash(scope: InferenceCacheScope | undefined):
   return createHash('sha256')
     .update([scope.tenantId ?? '', scope.userId, scope.workspaceId ?? ''].join('\u0000'))
     .digest('hex');
+}
+
+export async function runInferenceCacheOperation<T>(
+  operation: InferenceCacheOperation,
+  task: () => Promise<T>,
+  timeoutMs: number
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      task(),
+      new Promise<T>((_resolve, reject) => {
+        timeout = setTimeout(
+          () => reject(new InferenceCacheOperationTimeoutError(operation, timeoutMs)),
+          Math.max(1, timeoutMs)
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
 }
 
 export function isKvCacheExpired(ref: KvCacheRef, now: Date = new Date()): boolean {

--- a/packages/inference/src/manager.test.ts
+++ b/packages/inference/src/manager.test.ts
@@ -411,6 +411,25 @@ describe('@hypha/inference', () => {
     await expect(kvCache.get(kvB)).resolves.toEqual({ owner: 'b' });
   });
 
+  it('time-bounds direct inference cache manager operations', async () => {
+    const pending = () => new Promise<never>(() => undefined);
+    const manager = new InferenceCacheManager({
+      prefixCache: {
+        get: pending,
+        put: pending,
+        invalidate: async () => undefined,
+      },
+      kvCache: new InMemoryKvCacheProvider(),
+      operationTimeoutMs: 5,
+    });
+    await expect(
+      manager.getPrefix({ id: 'pending', version: '1', contentHash: 'a'.repeat(64) })
+    ).rejects.toMatchObject({
+      code: 'INFERENCE_CACHE_OPERATION_TIMEOUT',
+      operation: 'prefix_read',
+    });
+  });
+
   it('enforces KV cache expiry on inference manager reads', async () => {
     const kvCache = new InMemoryKvCacheProvider();
     const kv = {
@@ -639,6 +658,55 @@ describe('@hypha/inference', () => {
     });
     expect(failures).toHaveLength(3);
     expect(failures.every((failure) => failure.module === 'cache')).toBe(true);
+  });
+
+  it('time-bounds hanging cache providers before fail-open inference continues', async () => {
+    const pending = () => new Promise<never>(() => undefined);
+    const failures: RecoveryFailure[] = [];
+    const manager = new InferenceManager({
+      prefixCache: { get: pending, put: pending, invalidate: pending },
+      kvCache: { get: pending, put: pending, invalidate: pending },
+      cacheOperationTimeoutMs: 5,
+      onRecoveryFailure: (failure) => {
+        failures.push(failure);
+      },
+    });
+    manager.register({
+      id: 'mock',
+      infer: async () => ({
+        id: 'response_timeout_bypass',
+        output: 'completed',
+        nextKvCacheValue: { handle: 'next' },
+      }),
+    });
+    const kv = { id: 'kv-timeout', provider: 'mock', modelAlias: 'default', scope: 'run' as const };
+    const startedAt = Date.now();
+    const response = await manager.infer('mock', {
+      runId: 'run_cache_timeout',
+      stepId: 'step_cache_timeout',
+      modelAlias: 'default',
+      input: 'hello',
+      cachePolicy: {
+        prefix: { id: 'prefix-timeout', version: '1', contentHash: 'hash' },
+        kvCache: kv,
+        writeKvCache: { ref: kv },
+      },
+    });
+
+    expect(Date.now() - startedAt).toBeLessThan(250);
+    expect(response).toMatchObject({
+      id: 'response_timeout_bypass',
+      output: 'completed',
+      cache: {
+        bypassed: true,
+        issues: [
+          { operation: 'prefix_read', code: 'INFERENCE_CACHE_OPERATION_TIMEOUT' },
+          { operation: 'kv_read', code: 'INFERENCE_CACHE_OPERATION_TIMEOUT' },
+          { operation: 'kv_write', code: 'INFERENCE_CACHE_OPERATION_TIMEOUT' },
+        ],
+      },
+    });
+    expect(failures).toHaveLength(3);
   });
 
   it('reports provider failures without hiding the original inference error', async () => {

--- a/packages/inference/src/manager.ts
+++ b/packages/inference/src/manager.ts
@@ -1,6 +1,5 @@
 import { FrameworkError, type RecoveryFailure } from '@hypha/core';
-import { inferenceCacheScopeHash } from './cache';
-import { isKvCacheExpired } from './cache';
+import { inferenceCacheScopeHash, isKvCacheExpired, runInferenceCacheOperation } from './cache';
 import { classifyInferenceCacheFailure, classifyInferenceFailure } from './recovery';
 import type {
   InferenceCacheIssue,
@@ -37,11 +36,13 @@ export class InferenceManager {
   private readonly prefixCache?: PrefixCacheProvider;
   private readonly kvCache?: KvCacheProvider;
   private readonly cacheFailureMode: 'bypass' | 'strict';
+  private readonly cacheOperationTimeoutMs: number;
 
   constructor(private readonly options: InferenceManagerOptions = {}) {
     this.prefixCache = options.prefixCache;
     this.kvCache = options.kvCache;
     this.cacheFailureMode = options.cacheFailureMode ?? 'bypass';
+    this.cacheOperationTimeoutMs = Math.max(1, options.cacheOperationTimeoutMs ?? 250);
   }
 
   register(provider: InferenceProvider): void {
@@ -144,7 +145,14 @@ export class InferenceManager {
   ): Promise<CacheResolution<string>> {
     if (!ref || !this.prefixCache) return { value: null, issues: [] };
     try {
-      return { value: await this.prefixCache.get(ref), issues: [] };
+      return {
+        value: await runInferenceCacheOperation(
+          'prefix_read',
+          () => this.prefixCache!.get(ref),
+          this.cacheOperationTimeoutMs
+        ),
+        issues: [],
+      };
     } catch (error) {
       const issue = await this.handleCacheFailure(error, providerId, 'prefix_cache_read', request);
       return { value: null, missReason: 'error', issues: [issue] };
@@ -160,7 +168,11 @@ export class InferenceManager {
     if (!this.kvCache) return { value: null, missReason: 'not_configured', issues: [] };
     if (isKvCacheExpired(ref)) {
       try {
-        await this.kvCache.invalidate(ref, 'expired');
+        await runInferenceCacheOperation(
+          'invalidate',
+          () => this.kvCache!.invalidate(ref, 'expired'),
+          this.cacheOperationTimeoutMs
+        );
         return { value: null, missReason: 'expired', issues: [] };
       } catch (error) {
         const issue = await this.handleCacheFailure(error, providerId, 'cache_invalidate', request);
@@ -168,7 +180,11 @@ export class InferenceManager {
       }
     }
     try {
-      const value = await this.kvCache.get(ref);
+      const value = await runInferenceCacheOperation(
+        'kv_read',
+        () => this.kvCache!.get(ref),
+        this.cacheOperationTimeoutMs
+      );
       return value === null
         ? { value: null, missReason: 'missing', issues: [] }
         : { value, issues: [] };
@@ -227,7 +243,11 @@ export class InferenceManager {
     if (!this.kvCache) return { written: false, ref, issues: [] };
     if (isKvCacheExpired(ref)) {
       try {
-        await this.kvCache.invalidate(ref, 'expired');
+        await runInferenceCacheOperation(
+          'invalidate',
+          () => this.kvCache!.invalidate(ref, 'expired'),
+          this.cacheOperationTimeoutMs
+        );
         return { written: false, ref, issues: [] };
       } catch (error) {
         const issue = await this.handleCacheFailure(
@@ -242,7 +262,11 @@ export class InferenceManager {
     if ((policy.mode ?? 'write_through') === 'write_if_missing') {
       if (prepared.kvCacheHit) return { written: false, ref, issues: [] };
       try {
-        const existing = await this.kvCache.get(ref);
+        const existing = await runInferenceCacheOperation(
+          'kv_read',
+          () => this.kvCache!.get(ref),
+          this.cacheOperationTimeoutMs
+        );
         if (existing !== null) return { written: false, ref, issues: [] };
       } catch (error) {
         const issue = await this.handleCacheFailure(
@@ -257,7 +281,11 @@ export class InferenceManager {
     const value = policy.value !== undefined ? policy.value : response.nextKvCacheValue;
     if (value === undefined) return { written: false, ref, issues: [] };
     try {
-      await this.kvCache.put(ref, value);
+      await runInferenceCacheOperation(
+        'kv_write',
+        () => this.kvCache!.put(ref, value),
+        this.cacheOperationTimeoutMs
+      );
       return { written: true, ref, issues: [] };
     } catch (error) {
       const issue = await this.handleCacheFailure(

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -140,6 +140,7 @@ export interface InferenceManagerOptions {
   prefixCache?: PrefixCacheProvider;
   kvCache?: KvCacheProvider;
   cacheFailureMode?: 'bypass' | 'strict';
+  cacheOperationTimeoutMs?: number;
   providerRevision?: string;
   policyRevision?: string;
   specRevision?: string;


### PR DESCRIPTION
## 变更目标

确保挂起的 Inference Cache Provider 不会让推理或管理操作无限等待，使既有 fail-open 策略在超时异常下真正生效。

## 主要实现

- 新增统一 `InferenceCacheOperationTimeoutError` 与操作 runner。
- `InferenceManager` 的 prefix read、KV read/write/invalidate 默认限制为 250ms，可配置且 strict 模式仍可显式失败。
- `InferenceCacheManager` 的直接管理操作默认限制为 1000ms，可配置并返回同一结构化错误。
- 超时按既有 RecoveryFailure 路径记录，推理主结果在 bypass 模式下保持不变。

## 验证

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:unit`（65/65）
- `npm run test:packages`（136 suites / 1035 tests）
- Inference focused tests（26/26）
- `git diff --check`

## 所有权说明

变更仅涉及 `packages/inference`，在 `inference` Owner source branch 实现并合入 `dev`。
