### PR TITLE
fix(cache): enforce scoped index integrity

### DIFF
--- a/docs/architecture/serving-cache.md
+++ b/docs/architecture/serving-cache.md
@@ -103,6 +103,9 @@ never cached.
 `@hypha/serving-cache` exposes `CacheStore`, `NoopCacheStore`,
 `MemoryCacheStore`, `SQLiteCacheStore`, and `RedisCacheStore`. Store
 implementations persist versioned, runtime-validated `CacheEntry` records.
+Every store verifies that the physical lookup key matches `CacheEntry.key`;
+malformed or mismatched records are removed and treated as misses. Cache policy
+values are runtime-validated before a manager or middleware is created.
 Only `CachedModelResponseProjection` is persisted: content, tool calls, and
 usage. Provider `raw` payloads, old response ids, and arbitrary response
 metadata are excluded; every hit receives a new runtime response id. Memory,

--- a/docs/architecture/workcache.md
+++ b/docs/architecture/workcache.md
@@ -66,7 +66,8 @@ serialized block JSON, timestamps, expiry, and source event linkage.
 `HotIndexedWorkCacheStore` wraps either store and keeps an in-process index by
 block id and tree/cache key. Runtime lookup checks the hot index first, writes
 through to the backing store, and evicts low-utility entries by demand score and
-last update time.
+last update time. Hot and Redis indexes verify their tree/key binding before a
+hit; stale aliases are removed instead of returning a differently keyed block.
 
 The intended runtime layout is:
 
@@ -102,6 +103,9 @@ invalidation messages so peer hot indexes cannot continue serving a deleted
 block; Redis index replacement and deletion use atomic operations when the
 client supports them. Store calls are time-bounded and optional cache failures
 do not change the source event, inference result, or recovery outcome.
+Thinking Cache also requires the configured WorkCache scope before it can use
+its in-process singleflight map, so an unscoped request cannot be coalesced with
+another request even when no persistent write occurs.
 
 ## Reuse Rules
 

--- a/packages/serving-cache/src/policies.ts
+++ b/packages/serving-cache/src/policies.ts
@@ -1,4 +1,5 @@
 import type { CacheMode, CachePolicy } from './types';
+import { validateCachePolicy } from './schemas';
 
 export const defaultCachePolicy: CachePolicy = {
   enabled: false,
@@ -26,9 +27,9 @@ export function normalizeCachePolicy(policy: Partial<CachePolicy> = {}): CachePo
     },
   };
   if (normalized.mode === 'off') {
-    return { ...normalized, enabled: false };
+    return validateCachePolicy({ ...normalized, enabled: false });
   }
-  return normalized;
+  return validateCachePolicy(normalized);
 }
 
 export function cacheModeAllowsRead(mode: CacheMode): boolean {

--- a/packages/serving-cache/src/prefix-shape.ts
+++ b/packages/serving-cache/src/prefix-shape.ts
@@ -22,8 +22,11 @@ interface PrefixCacheShapeSnapshot {
 
 export class PrefixCacheShapeTracker {
   private readonly snapshots = new Map<string, PrefixCacheShapeSnapshot>();
+  private readonly maxSnapshots: number;
 
-  constructor(private readonly maxSnapshots = 5000) {}
+  constructor(maxSnapshots = 5000) {
+    this.maxSnapshots = Math.max(1, maxSnapshots);
+  }
 
   observe(input: PrefixCacheShapeInput): PrefixCacheShapeObservation {
     const key = trackerKey(input);

--- a/packages/serving-cache/src/schemas.ts
+++ b/packages/serving-cache/src/schemas.ts
@@ -98,7 +98,7 @@ export const cacheEntrySchema = z
         classification: z.enum(['public', 'internal', 'confidential', 'restricted']).optional(),
         prefixMetadata: z.unknown().optional(),
       })
-      .passthrough()
+      .strict()
       .optional(),
   })
   .strict();
@@ -163,6 +163,10 @@ export const servingCacheJsonSchemas = {
 
 export function validateCacheEntry<T = unknown>(input: unknown): CacheEntry<T> {
   return cacheEntrySchema.parse(input) as CacheEntry<T>;
+}
+
+export function validateCachePolicy(input: unknown): CachePolicy {
+  return cachePolicySchema.parse(input);
 }
 
 export function validateCachedModelResponseProjection(

--- a/packages/serving-cache/src/serving-cache.test.ts
+++ b/packages/serving-cache/src/serving-cache.test.ts
@@ -6,6 +6,7 @@ import type { ModelProvider, ModelRequest, ModelResponse } from '@hypha/models';
 import { ServingCacheManager } from './cache-manager';
 import { buildPromptPrefixMetadata, createLLMCacheKey } from './key';
 import { CachedLLMProvider } from './middleware/llm-cache-middleware';
+import { normalizeCachePolicy } from './policies';
 import { MemoryCacheStore } from './stores/memory-store';
 import { RedisCacheStore, type RedisCacheClient } from './stores/redis-store';
 import { SQLiteCacheStore } from './stores/sqlite-store';
@@ -472,6 +473,67 @@ describe('@hypha/serving-cache', () => {
       )
     ).rejects.toThrow(/maximum/);
     expect(await store.get('large')).toBeNull();
+  });
+
+  it('rejects unknown metadata and invalid runtime policy values', () => {
+    expect(() =>
+      validateCacheEntry({
+        key: 'strict-metadata',
+        value: { content: 'ok' },
+        createdAt: 1,
+        metadata: {
+          provider: 'mock',
+          model: 'model',
+          cacheType: 'exact',
+          secretValue: 'must-not-pass-through',
+        },
+      })
+    ).toThrow(/Unrecognized key/u);
+    expect(() => normalizeCachePolicy({ operationTimeoutMs: 0 })).toThrow();
+    expect(() => normalizeCachePolicy({ maxEntryBytes: -1 })).toThrow();
+  });
+
+  it('enforces physical-to-logical key binding in cache stores', async () => {
+    const memory = new MemoryCacheStore();
+    await expect(
+      memory.set('physical-key', {
+        key: 'different-logical-key',
+        value: { content: 'poison' },
+        createdAt: 1,
+      })
+    ).rejects.toThrow(/does not match/u);
+
+    const values = new Map<string, string>();
+    const client: RedisCacheClient = {
+      async get(key) {
+        return values.get(key) ?? null;
+      },
+      async set(key, value) {
+        values.set(key, value);
+        return 'OK';
+      },
+      async del(...keys) {
+        let deleted = 0;
+        for (const key of keys) deleted += Number(values.delete(key));
+        return deleted;
+      },
+      async scan() {
+        return ['0', [...values.keys()]];
+      },
+    };
+    values.set(
+      'binding:physical-key',
+      JSON.stringify({
+        schemaVersion: '1.0',
+        keyVersion: '1',
+        key: 'different-logical-key',
+        value: { content: 'poison' },
+        createdAt: 1,
+      })
+    );
+    const redis = new RedisCacheStore({ client, prefix: 'binding:' });
+    expect(await redis.get('physical-key')).toBeNull();
+    expect(values.has('binding:physical-key')).toBe(false);
   });
 
   it('round-trips and clears versioned entries through a Redis-compatible store', async () => {

--- a/packages/serving-cache/src/stores/memory-store.ts
+++ b/packages/serving-cache/src/stores/memory-store.ts
@@ -35,6 +35,7 @@ export class MemoryCacheStore implements CacheStore {
 
   async set<T>(key: string, entry: CacheEntry<T>): Promise<void> {
     validateCacheEntry(entry);
+    assertCacheKeyBinding(key, entry.key);
     const existing = this.entries.get(key);
     if (existing) this.sizeBytes -= entrySize(existing);
     this.entries.delete(key);
@@ -86,6 +87,12 @@ export class MemoryCacheStore implements CacheStore {
       this.entries.delete(oldestKey);
       this.evictions += 1;
     }
+  }
+}
+
+function assertCacheKeyBinding(requestedKey: string, entryKey: string): void {
+  if (requestedKey !== entryKey) {
+    throw new Error('Serving Cache store key does not match CacheEntry.key.');
   }
 }
 

--- a/packages/serving-cache/src/stores/redis-store.ts
+++ b/packages/serving-cache/src/stores/redis-store.ts
@@ -30,7 +30,12 @@ export class RedisCacheStore implements CacheStore {
     const raw = await this.options.client.get(this.key(key));
     if (!raw) return null;
     try {
-      return validateCacheEntry<T>(JSON.parse(raw));
+      const entry = validateCacheEntry<T>(JSON.parse(raw));
+      if (entry.key !== key) {
+        await this.options.client.del(this.key(key));
+        return null;
+      }
+      return entry;
     } catch {
       await this.options.client.del(this.key(key));
       return null;
@@ -39,6 +44,9 @@ export class RedisCacheStore implements CacheStore {
 
   async set<T>(key: string, entry: CacheEntry<T>): Promise<void> {
     validateCacheEntry(entry);
+    if (entry.key !== key) {
+      throw new Error('Serving Cache store key does not match CacheEntry.key.');
+    }
     const ttlMs = entry.expiresAt === undefined ? undefined : entry.expiresAt - this.now();
     if (ttlMs !== undefined && ttlMs <= 0) {
       await this.delete(key);

--- a/packages/serving-cache/src/stores/sqlite-store.ts
+++ b/packages/serving-cache/src/stores/sqlite-store.ts
@@ -87,6 +87,9 @@ export class SQLiteCacheStore implements CacheStore {
 
   async set<T>(key: string, entry: CacheEntry<T>): Promise<void> {
     validateCacheEntry(entry);
+    if (entry.key !== key) {
+      throw new Error('Serving Cache store key does not match CacheEntry.key.');
+    }
     this.db
       .prepare(
         'INSERT OR REPLACE INTO cache_entries ' +

--- a/packages/workcache/src/hardening.test.ts
+++ b/packages/workcache/src/hardening.test.ts
@@ -5,6 +5,7 @@ import { InMemoryWorkCacheInvalidationBus } from './invalidation-bus';
 import { WorkCacheManager } from './manager';
 import { validateCacheBlock } from './schemas';
 import { MemoryWorkCacheStore } from './stores/memory-store';
+import { HotIndexedWorkCacheStore } from './stores/hot-index-store';
 import { RedisWorkCacheStore, type RedisWorkCacheClient } from './stores/redis-store';
 
 describe('@hypha/workcache hardening', () => {
@@ -196,6 +197,59 @@ describe('@hypha/workcache hardening', () => {
     });
   });
 
+  it('removes stale hot-index aliases when a block identity changes', async () => {
+    const backing = new MemoryWorkCacheStore();
+    const hot = new HotIndexedWorkCacheStore(backing);
+    const original = validCacheBlock('shared-block', 'old-key');
+    await hot.set(original);
+    await hot.set({ ...original, cacheKey: 'new-key', updatedAt: 1001 });
+
+    expect(await hot.getByCacheKey('ToolTree', 'old-key')).toBeNull();
+    expect(await hot.getByCacheKey('ToolTree', 'new-key')).toMatchObject({
+      id: 'shared-block',
+      cacheKey: 'new-key',
+    });
+  });
+
+  it('quarantines a Redis index that points at a block with a different key', async () => {
+    const values = new Map<string, string>();
+    const client: RedisWorkCacheClient = {
+      async get(key) {
+        return values.get(key) ?? null;
+      },
+      async set(key, value) {
+        values.set(key, value);
+        return 'OK';
+      },
+      async del(...keys) {
+        let deleted = 0;
+        for (const key of keys) deleted += Number(values.delete(key));
+        return deleted;
+      },
+      async scan() {
+        return ['0', [...values.keys()]];
+      },
+    };
+    const block = validCacheBlock('poison-block', 'actual-key');
+    values.set('binding:block:poison-block', JSON.stringify(block));
+    values.set('binding:index:ToolTree:requested-key', 'poison-block');
+    const store = new RedisWorkCacheStore({ client, prefix: 'binding:' });
+
+    expect(await store.getByCacheKey('ToolTree', 'requested-key')).toBeNull();
+    expect(values.has('binding:index:ToolTree:requested-key')).toBe(false);
+    expect(values.has('binding:block:poison-block')).toBe(true);
+  });
+
+  it('rejects invalid runtime policy values before creating a manager', () => {
+    expect(
+      () =>
+        new WorkCacheManager({
+          store: new MemoryWorkCacheStore(),
+          policy: { enabled: true, store: 'memory', operationTimeoutMs: 0 },
+        })
+    ).toThrow();
+  });
+
   it('rejects missing block values and bypasses non-JSON cache payloads', async () => {
     expect(() =>
       validateCacheBlock({
@@ -281,4 +335,23 @@ function baseEvent(
 
 function eventScope(event: FrameworkEvent) {
   return { userId: event.userId, sessionId: event.sessionId };
+}
+
+function validCacheBlock(id: string, cacheKey: string) {
+  return {
+    schemaVersion: '1.0' as const,
+    keyVersion: '1' as const,
+    id,
+    treeType: 'ToolTree' as const,
+    nodeType: 'tool' as const,
+    cacheKey,
+    value: { output: 'ok' },
+    createdAt: 1000,
+    updatedAt: 1000,
+    sourceEventId: 'event',
+    sourceEventType: 'tool.call.completed' as const,
+    scope: { userId: 'owner' },
+    validity: { status: 'valid' as const, provenanceHash: 'sha256:proof' },
+    utility: { score: 1 },
+  };
 }

--- a/packages/workcache/src/policies.ts
+++ b/packages/workcache/src/policies.ts
@@ -1,4 +1,5 @@
 import type { CacheTreeType, PartialWorkCachePolicy, WorkCachePolicy } from './types';
+import { validateWorkCachePolicy } from './schemas';
 
 export const WORKCACHE_TREE_TYPES: CacheTreeType[] = [
   'PlanTree',
@@ -35,7 +36,7 @@ export const defaultWorkCachePolicy: WorkCachePolicy = {
 
 export function normalizeWorkCachePolicy(policy: PartialWorkCachePolicy = {}): WorkCachePolicy {
   const enabled = policy.enabled ?? (policy.store !== undefined && policy.store !== 'off');
-  return {
+  return validateWorkCachePolicy({
     ...defaultWorkCachePolicy,
     ...policy,
     enabled,
@@ -58,5 +59,5 @@ export function normalizeWorkCachePolicy(policy: PartialWorkCachePolicy = {}): W
       },
       {} as WorkCachePolicy['trees']
     ),
-  };
+  });
 }

--- a/packages/workcache/src/reasoning-inference-cache.test.ts
+++ b/packages/workcache/src/reasoning-inference-cache.test.ts
@@ -266,6 +266,41 @@ describe('WorkCachedInferenceProvider', () => {
     expect(providerCalls).toBe(2);
     expect(await store.list()).toEqual([]);
   });
+
+  it('does not coalesce unscoped computations under the default user boundary', async () => {
+    let providerCalls = 0;
+    const store = new MemoryWorkCacheStore();
+    const cached = new WorkCachedInferenceProvider({
+      provider: {
+        id: 'unscoped-provider',
+        async infer() {
+          providerCalls += 1;
+          await Promise.resolve();
+          return { id: `response-${providerCalls}`, output: { content: 'private' } };
+        },
+      },
+      manager: new WorkCacheManager({
+        store,
+        policy: { enabled: true, store: 'memory' },
+      }),
+    });
+    const unscoped: InferenceRequest = {
+      runId: 'run-unscoped',
+      stepId: 'step-1',
+      sessionId: 'session-shared',
+      modelAlias: 'model-a',
+      input: { messages: [{ role: 'user', content: 'private' }] },
+      metadata: { reasoningCacheIdentity: 'same-node' },
+    };
+
+    await Promise.all([
+      cached.infer(unscoped),
+      cached.infer({ ...unscoped, runId: 'run-other', stepId: 'step-2' }),
+    ]);
+
+    expect(providerCalls).toBe(2);
+    expect(await store.list('ComputationTree')).toEqual([]);
+  });
 });
 
 function request(

--- a/packages/workcache/src/stores/hot-index-store.ts
+++ b/packages/workcache/src/stores/hot-index-store.ts
@@ -13,7 +13,7 @@ export class HotIndexedWorkCacheStore implements WorkCacheStore {
     private readonly backing: WorkCacheStore,
     options: HotIndexedWorkCacheStoreOptions = {}
   ) {
-    this.maxEntries = options.maxEntries ?? 5000;
+    this.maxEntries = Math.max(1, options.maxEntries ?? 5000);
   }
 
   async get<T = unknown>(blockId: string): Promise<CacheBlock<T> | null> {
@@ -35,14 +35,17 @@ export class HotIndexedWorkCacheStore implements WorkCacheStore {
     const hotId = this.keyIndex.get(indexKey(treeType, cacheKey));
     if (hotId) {
       const hot = this.blocks.get(hotId);
-      if (hot) {
+      if (hot && hot.treeType === treeType && hot.cacheKey === cacheKey) {
         this.blocks.delete(hotId);
         this.blocks.set(hotId, hot);
         return hot as CacheBlock<T>;
       }
-      this.keyIndex.delete(indexKey(treeType, cacheKey));
+      this.deleteKeyBinding(treeType, cacheKey, hotId);
     }
     const block = await this.backing.getByCacheKey<T>(treeType, cacheKey);
+    if (block && (block.treeType !== treeType || block.cacheKey !== cacheKey)) {
+      return null;
+    }
     if (block) this.index(block);
     return block;
   }
@@ -54,7 +57,7 @@ export class HotIndexedWorkCacheStore implements WorkCacheStore {
 
   async delete(blockId: string): Promise<void> {
     const hot = this.blocks.get(blockId);
-    if (hot) this.keyIndex.delete(indexKey(hot.treeType, hot.cacheKey));
+    if (hot) this.deleteKeyBinding(hot.treeType, hot.cacheKey, blockId);
     this.blocks.delete(blockId);
     await this.backing.delete(blockId);
   }
@@ -119,6 +122,13 @@ export class HotIndexedWorkCacheStore implements WorkCacheStore {
   }
 
   private index<T>(block: CacheBlock<T>): void {
+    const previous = this.blocks.get(block.id);
+    if (
+      previous &&
+      (previous.treeType !== block.treeType || previous.cacheKey !== block.cacheKey)
+    ) {
+      this.deleteKeyBinding(previous.treeType, previous.cacheKey, block.id);
+    }
     this.blocks.set(block.id, block as CacheBlock);
     this.keyIndex.set(indexKey(block.treeType, block.cacheKey), block.id);
     this.evictIfNeeded();
@@ -134,8 +144,13 @@ export class HotIndexedWorkCacheStore implements WorkCacheStore {
       })[0];
       if (!candidate) return;
       this.blocks.delete(candidate.id);
-      this.keyIndex.delete(indexKey(candidate.treeType, candidate.cacheKey));
+      this.deleteKeyBinding(candidate.treeType, candidate.cacheKey, candidate.id);
     }
+  }
+
+  private deleteKeyBinding(treeType: CacheTreeType, cacheKey: string, blockId: string): void {
+    const key = indexKey(treeType, cacheKey);
+    if (this.keyIndex.get(key) === blockId) this.keyIndex.delete(key);
   }
 }
 

--- a/packages/workcache/src/stores/redis-store.ts
+++ b/packages/workcache/src/stores/redis-store.ts
@@ -45,7 +45,10 @@ export class RedisWorkCacheStore implements WorkCacheStore {
     const blockId = await this.options.client.get(indexKey);
     if (!blockId) return null;
     const block = await this.get<T>(blockId);
-    if (!block) await this.options.client.del(indexKey);
+    if (!block || block.treeType !== treeType || block.cacheKey !== cacheKey) {
+      await this.options.client.del(indexKey);
+      return null;
+    }
     return block;
   }
 

--- a/packages/workcache/src/thinking-cache.ts
+++ b/packages/workcache/src/thinking-cache.ts
@@ -108,6 +108,13 @@ export class ThinkingCache {
         metadata: { hit: false, kind: identity.kind, ...location },
       };
     }
+    if (!scopeSatisfies(identity.scope, this.manager.policy.scopeRequirement)) {
+      return {
+        hit: false,
+        reason: 'scope_missing',
+        metadata: { hit: false, kind: identity.kind, ...location },
+      };
+    }
     try {
       const result = await this.manager.lookup<ThinkingCacheEntry<T>>({
         treeType: 'ComputationTree',
@@ -167,6 +174,7 @@ export class ThinkingCache {
       source: 'computed',
     };
     if (!this.enabled) return metadata;
+    if (!scopeSatisfies(identity.scope, this.manager.policy.scopeRequirement)) return metadata;
 
     const timestamp = this.now();
     const ttlMs = this.manager.policy.trees.ComputationTree.ttlMs;
@@ -232,6 +240,18 @@ export class ThinkingCache {
       hydrateCached?: (value: T, source: 'store' | 'in_flight') => T;
     }
   ): Promise<{ value: T; metadata: ThinkingCacheMetadata }> {
+    if (!scopeSatisfies(options.identity.scope, this.manager.policy.scopeRequirement)) {
+      const location = thinkingCacheLocation(options.identity);
+      return {
+        value: await options.compute(),
+        metadata: {
+          hit: false,
+          kind: options.identity.kind,
+          ...location,
+          source: 'computed',
+        },
+      };
+    }
     const lookup = await this.lookup<T>(options.identity, options.context);
     if (lookup.hit) {
       return {
@@ -296,6 +316,15 @@ export class ThinkingCache {
       // Cache observability is best effort and cannot change inference behavior.
     }
   }
+}
+
+function scopeSatisfies(
+  scope: ThinkingCacheScope,
+  requirement: WorkCacheManager['policy']['scopeRequirement']
+): boolean {
+  if (requirement === 'none') return true;
+  if (requirement === 'session') return Boolean(scope.userId && scope.sessionId);
+  return Boolean(scope.userId);
 }
 
 function thinkingCacheLocation(identity: ThinkingCacheIdentity): {


### PR DESCRIPTION
## Summary
- enforce runtime-valid Cache policies and strict CacheEntry metadata
- verify physical/logical key bindings across Serving Cache and WorkCache stores
- remove stale hot/Redis aliases instead of returning differently keyed blocks
- prevent unscoped Thinking Cache requests from participating in singleflight

## Validation
- npm run lint
- npm run typecheck
- npm run build
- npm run test:unit (73)
- npm run test:packages (1101)
- focused Cache tests (34)