### PR TITLE
feat(execution): add governed result cache

### DIFF
--- a/docs/api/framework.md
+++ b/docs/api/framework.md
@@ -201,9 +201,13 @@ strict Zod/JSON Schema validators:
 | `GovernedExecutionPort`           | Fails closed on invalid scope, operation, approval, cancellation, deadline, authorization, or verifier evidence before calling an injected `ExecutionOperationDispatcher`.       |
 | `DefaultExecutionOutputPlanner`   | Selects final file mutations using safe relative patterns, integrity evidence, Artifact/byte budgets, and deterministic ordering.                                                |
 | `DefaultExecutionOutputCollector` | Creates/finalizes output Artifacts through an injected manager and verifies returned schema, scope, provenance, integrity, status, and version identity.                         |
+| `ExecutionResultCache`            | Reuses only completed, deterministic read-only result projections under an exact user/Workspace scope, bounded Store timeout, validity hashes, and Artifact integrity checks.    |
 
 Concrete process, container, remote sandbox, or object-store implementations remain adapter-owned.
 An implementation is not implied merely because the framework contract or registry entry exists.
+An Execution Cache hit is a reusable projection, not a new execution receipt: Workspace writes,
+external effects, irreversible operations, unstable environments, failed results, and unverifiable
+Artifact references always bypass or invalidate the Cache.
 
 ## Evaluation, Replay, and Regression
 
@@ -571,13 +575,15 @@ same policy and trace path. See [Governed Memory](../architecture/memory.md).
 
 `@hypha/adapters-local` provides development and self-hosted adapters:
 
-| Adapter                    | Storage                 | Purpose                                                                                                                                                                                      |
-| -------------------------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `SQLiteEventStore`         | SQLite or JSON fallback | Event store and trace recorder for replay, audit, regression, and projection. Uses `node:sqlite` when available, otherwise `better-sqlite3`, with JSON sidecar fallback only in `auto` mode. |
-| `SQLiteStructuredStore`    | SQLite or JSON fallback | Structured source-of-truth records with indexed tables. Uses the same SQLite/JSON fallback behavior.                                                                                         |
-| `LocalVectorIndexProvider` | JSON file               | Persistent local vector search with metadata filters.                                                                                                                                        |
-| `FileArtifactStore`        | filesystem              | Artifact bytes and hash metadata under a configured root.                                                                                                                                    |
-| `MockEmbeddingProvider`    | deterministic vectors   | Repeatable local embeddings for tests and offline development.                                                                                                                               |
+| Adapter                          | Storage                 | Purpose                                                                                                                                                                                      |
+| -------------------------------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SQLiteEventStore`               | SQLite or JSON fallback | Event store and trace recorder for replay, audit, regression, and projection. Uses `node:sqlite` when available, otherwise `better-sqlite3`, with JSON sidecar fallback only in `auto` mode. |
+| `SQLiteStructuredStore`          | SQLite or JSON fallback | Structured source-of-truth records with indexed tables. Uses the same SQLite/JSON fallback behavior.                                                                                         |
+| `LocalVectorIndexProvider`       | JSON file               | Persistent local vector search with metadata filters.                                                                                                                                        |
+| `FileArtifactStore`              | filesystem              | Artifact bytes and hash metadata under a configured root.                                                                                                                                    |
+| `MockEmbeddingProvider`          | deterministic vectors   | Repeatable local embeddings for tests and offline development.                                                                                                                               |
+| `InMemoryExecutionCacheStore`    | bounded memory          | Local `ExecutionCacheStore` with LRU-style eviction, byte limits, defensive copies, and strict physical/logical key binding.                                                                 |
+| `NodeExecutionFingerprintHasher` | Node crypto             | SHA-256 implementation for canonical Execution command, validity, scope, and Result Cache keys.                                                                                              |
 
 `createLocalStorageBackbone(options)` returns a complete local stack: `eventStore`, `structured`, `vector`, `artifacts`, `embeddings`, `memory`, and storage `profiles`. Use it when a local runtime needs event persistence, structured memory, semantic recall, and artifact storage without wiring each adapter manually.
 

--- a/packages/adapters-local/src/in-memory-execution-cache-store.test.ts
+++ b/packages/adapters-local/src/in-memory-execution-cache-store.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ExecutionResultCache,
+  canonicalizeExecutionFingerprintInput,
+  executionCacheEntryProjectionExample,
+  executionCacheValidityInputExample,
+  executionCommandFingerprintInputExample,
+} from '@hypha/core';
+import {
+  InMemoryExecutionCacheStore,
+  NodeExecutionFingerprintHasher,
+} from './in-memory-execution-cache-store';
+
+describe('InMemoryExecutionCacheStore', () => {
+  it('provides a bounded, defensively copied local Execution Cache', async () => {
+    const store = new InMemoryExecutionCacheStore({ maxEntries: 1 });
+    const hasher = new NodeExecutionFingerprintHasher();
+    const cache = new ExecutionResultCache({ store, hasher, now: () => 1000 });
+
+    for (const userId of ['one', 'two']) {
+      const commandHash = await hasher.hashUtf8(
+        canonicalizeExecutionFingerprintInput(executionCommandFingerprintInputExample)
+      );
+      const validityHash = await hasher.hashUtf8(
+        canonicalizeExecutionFingerprintInput(executionCacheValidityInputExample)
+      );
+      expect(
+        await cache.write({
+          scope: { userId, workspaceId: 'workspace' },
+          command: executionCommandFingerprintInputExample,
+          validity: executionCacheValidityInputExample,
+          sideEffectLevel: 'read',
+          environmentFingerprintStatus: 'resolved',
+          projection: {
+            ...executionCacheEntryProjectionExample,
+            commandHash,
+            validityHash,
+            validity: executionCacheValidityInputExample,
+            artifacts: [],
+            resultMetadata: {
+              ...executionCacheEntryProjectionExample.resultMetadata,
+              status: 'completed',
+            },
+          },
+        })
+      ).toBe(true);
+    }
+
+    expect(store.stats()).toMatchObject({ entries: 1, evictions: 1 });
+    await expect(
+      cache.lookup({
+        scope: { userId: 'one', workspaceId: 'workspace' },
+        command: executionCommandFingerprintInputExample,
+        validity: executionCacheValidityInputExample,
+        sideEffectLevel: 'read',
+        environmentFingerprintStatus: 'resolved',
+      })
+    ).resolves.toMatchObject({ hit: false, reason: 'not_found' });
+  });
+});

--- a/packages/adapters-local/src/in-memory-execution-cache-store.ts
+++ b/packages/adapters-local/src/in-memory-execution-cache-store.ts
@@ -1,0 +1,102 @@
+import { createHash } from 'crypto';
+import {
+  validateExecutionCacheRecord,
+  type ExecutionCacheRecord,
+  type ExecutionCacheStore,
+  type ExecutionFingerprintHasher,
+} from '@hypha/core';
+
+export interface InMemoryExecutionCacheStoreOptions {
+  maxEntries?: number;
+  maxBytes?: number;
+}
+
+export interface InMemoryExecutionCacheStoreStats {
+  entries: number;
+  sizeBytes: number;
+  evictions: number;
+}
+
+export class NodeExecutionFingerprintHasher implements ExecutionFingerprintHasher {
+  readonly algorithm = 'sha256' as const;
+
+  async hashUtf8(canonicalValue: string): Promise<string> {
+    return `sha256:${createHash('sha256').update(canonicalValue, 'utf8').digest('hex')}`;
+  }
+}
+
+/** Bounded local reference store. Durable or shared providers implement the same Core port. */
+export class InMemoryExecutionCacheStore implements ExecutionCacheStore {
+  private readonly records = new Map<string, ExecutionCacheRecord>();
+  private readonly maxEntries: number;
+  private readonly maxBytes: number;
+  private sizeBytes = 0;
+  private evictions = 0;
+
+  constructor(options: InMemoryExecutionCacheStoreOptions = {}) {
+    this.maxEntries = positiveInteger(options.maxEntries ?? 1000, 'maxEntries');
+    this.maxBytes = positiveInteger(options.maxBytes ?? 64 * 1024 * 1024, 'maxBytes');
+  }
+
+  async get(key: string): Promise<ExecutionCacheRecord | null> {
+    const record = this.records.get(key);
+    if (!record) return null;
+    this.records.delete(key);
+    this.records.set(key, record);
+    return clone(record);
+  }
+
+  async set(key: string, rawRecord: ExecutionCacheRecord): Promise<void> {
+    const record = validateExecutionCacheRecord(rawRecord);
+    if (record.key !== key) {
+      throw new Error('Execution Cache store key does not match ExecutionCacheRecord.key.');
+    }
+    const previous = this.records.get(key);
+    if (previous) this.sizeBytes -= recordSize(previous);
+    this.records.delete(key);
+    this.records.set(key, clone(record));
+    this.sizeBytes += recordSize(record);
+    this.prune();
+  }
+
+  async delete(key: string): Promise<void> {
+    const previous = this.records.get(key);
+    if (previous) this.sizeBytes -= recordSize(previous);
+    this.records.delete(key);
+  }
+
+  async clear(): Promise<void> {
+    this.records.clear();
+    this.sizeBytes = 0;
+  }
+
+  stats(): InMemoryExecutionCacheStoreStats {
+    return { entries: this.records.size, sizeBytes: this.sizeBytes, evictions: this.evictions };
+  }
+
+  private prune(): void {
+    while (this.records.size > this.maxEntries || this.sizeBytes > this.maxBytes) {
+      const oldestKey = this.records.keys().next().value as string | undefined;
+      if (!oldestKey) return;
+      const record = this.records.get(oldestKey);
+      if (record) this.sizeBytes -= recordSize(record);
+      this.records.delete(oldestKey);
+      this.evictions += 1;
+    }
+  }
+}
+
+function recordSize(record: ExecutionCacheRecord): number {
+  return record.sizeBytes ?? Buffer.byteLength(JSON.stringify(record), 'utf8');
+}
+
+function positiveInteger(value: number, field: string): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new TypeError(`${field} must be a positive integer.`);
+  }
+  return value;
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/packages/adapters-local/src/index.ts
+++ b/packages/adapters-local/src/index.ts
@@ -50,6 +50,7 @@ export * from './local-sandbox-lifecycle';
 export * from './local-active-execution-registry';
 export * from './local-process-result';
 export * from './local-process-execution-provider';
+export * from './in-memory-execution-cache-store';
 export * from './artifact-content-io';
 export * from './artifact-store-adapter-error';
 export * from './local-artifact-files';

--- a/packages/core/src/contracts/execution-cache.ts
+++ b/packages/core/src/contracts/execution-cache.ts
@@ -87,8 +87,98 @@ export interface ExecutionCacheEntryProjection {
   artifacts: ExecutionCacheArtifactReference[];
 }
 
+/** Mandatory ownership boundary for persisted Execution Cache records. */
+export interface ExecutionCacheScope {
+  tenantId?: string;
+  userId: string;
+  workspaceId: string;
+}
+
+/** Versioned envelope persisted by an Execution Result Cache store. */
+export interface ExecutionCacheRecord {
+  schemaVersion: '1.0';
+  keyVersion: '1';
+  key: string;
+  scope: ExecutionCacheScope;
+  projection: ExecutionCacheEntryProjection;
+  createdAt: number;
+  expiresAt?: number;
+  sizeBytes?: number;
+}
+
+export interface ExecutionCacheStore {
+  get(key: string): Promise<ExecutionCacheRecord | null>;
+  set(key: string, record: ExecutionCacheRecord): Promise<void>;
+  delete(key: string): Promise<void>;
+  clear?(): Promise<void>;
+  close?(): Promise<void>;
+}
+
+export interface ExecutionCacheArtifactVerifier {
+  verify(
+    scope: ExecutionCacheScope,
+    artifacts: ExecutionCacheArtifactReference[]
+  ): Promise<boolean>;
+}
+
+export type ExecutionCacheFailureMode = 'bypass' | 'strict';
+
+export type ExecutionCacheMissReason =
+  | 'not_found'
+  | 'expired'
+  | 'scope_mismatch'
+  | 'key_mismatch'
+  | 'validity_changed'
+  | 'artifact_verification_unavailable'
+  | 'artifact_verification_failed'
+  | 'environment_fingerprint_unavailable'
+  | 'workspace_write'
+  | 'external_side_effect'
+  | 'irreversible_side_effect'
+  | 'not_cacheable_status'
+  | 'store_unavailable'
+  | 'entry_oversized'
+  | 'corrupt';
+
+export interface ExecutionCacheLookupInput {
+  scope: ExecutionCacheScope;
+  command: ExecutionCommandFingerprintInput;
+  validity: ExecutionCacheValidityInput;
+  sideEffectLevel: SideEffectLevel;
+  environmentFingerprintStatus: ExecutionEnvironmentFingerprintResolution['status'];
+}
+
+export interface ExecutionCacheWriteInput extends ExecutionCacheLookupInput {
+  projection: ExecutionCacheEntryProjection;
+  ttlMs?: number;
+}
+
+export type ExecutionCacheLookupResult =
+  | {
+      hit: true;
+      key: string;
+      projection: ExecutionCacheEntryProjection;
+      ageMs: number;
+    }
+  | { hit: false; reason: ExecutionCacheMissReason; key?: string };
+
+export interface ExecutionCacheEvent {
+  type:
+    | 'execution.cache.lookup'
+    | 'execution.cache.hit'
+    | 'execution.cache.miss'
+    | 'execution.cache.write'
+    | 'execution.cache.invalidate'
+    | 'execution.cache.bypass';
+  key?: string;
+  scope: ExecutionCacheScope;
+  reason?: ExecutionCacheMissReason;
+  ageMs?: number;
+}
+
 export type ExecutionCacheReuseBlockReason =
   | 'environment_fingerprint_unavailable'
+  | 'workspace_write'
   | 'external_side_effect'
   | 'irreversible_side_effect';
 

--- a/packages/core/src/modules/execution-cache/execution-cache.test.ts
+++ b/packages/core/src/modules/execution-cache/execution-cache.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import { createHash } from 'crypto';
+import type {
+  ExecutionCacheRecord,
+  ExecutionCacheStore,
+  ExecutionFingerprintHasher,
+} from '../../contracts/execution-cache';
 import {
   assessExecutionCacheReuse,
   canonicalizeExecutionFingerprintInput,
+  ExecutionResultCache,
   executionCacheEntryProjectionExample,
   executionCacheJsonSchemas,
   executionCacheValidityInputExample,
@@ -40,6 +47,8 @@ describe('Execution Cache boundary contracts', () => {
         'ExecutionCacheArtifactReference',
         'ExecutionCacheResultMetadata',
         'ExecutionCacheEntryProjection',
+        'ExecutionCacheScope',
+        'ExecutionCacheRecord',
       ])
     );
     expect(executionCacheJsonSchemas.ExecutionCacheEntryProjection.required).toContain('validity');
@@ -145,6 +154,12 @@ describe('Execution Cache boundary contracts', () => {
     ).toEqual({ reusable: false, reason: 'environment_fingerprint_unavailable' });
     expect(
       assessExecutionCacheReuse({
+        sideEffectLevel: 'write',
+        environmentFingerprintStatus: 'resolved',
+      })
+    ).toEqual({ reusable: false, reason: 'workspace_write' });
+    expect(
+      assessExecutionCacheReuse({
         sideEffectLevel: 'external_effect',
         environmentFingerprintStatus: 'resolved',
       })
@@ -156,4 +171,148 @@ describe('Execution Cache boundary contracts', () => {
       })
     ).toEqual({ reusable: false, reason: 'irreversible_side_effect' });
   });
+
+  it('stores and reuses only matching scoped, read-only projections', async () => {
+    const store = new TestExecutionCacheStore();
+    const cache = new ExecutionResultCache({ store, hasher, now: () => 1000 });
+    const input = cacheInput();
+    const projection = await projectionFor(input.command, input.validity);
+
+    await expect(cache.write({ ...input, projection })).resolves.toBe(true);
+    await expect(cache.lookup(input)).resolves.toMatchObject({
+      hit: true,
+      projection: { resultMetadata: { status: 'completed' } },
+    });
+    await expect(
+      cache.lookup({ ...input, scope: { userId: 'other', workspaceId: 'workspace_01' } })
+    ).resolves.toMatchObject({ hit: false, reason: 'not_found' });
+  });
+
+  it('never caches Workspace writes or non-completed command results', async () => {
+    const cache = new ExecutionResultCache({
+      store: new TestExecutionCacheStore(),
+      hasher,
+    });
+    const input = cacheInput();
+    const projection = await projectionFor(input.command, input.validity);
+
+    await expect(cache.write({ ...input, sideEffectLevel: 'write', projection })).resolves.toBe(
+      false
+    );
+    await expect(
+      cache.write({
+        ...input,
+        projection: {
+          ...projection,
+          resultMetadata: { ...projection.resultMetadata, status: 'failed' },
+        },
+      })
+    ).resolves.toBe(false);
+  });
+
+  it('fails closed on Artifact references unless their integrity can be verified', async () => {
+    const store = new TestExecutionCacheStore();
+    const input = cacheInput();
+    const projection = await projectionFor(input.command, input.validity, [
+      { artifactRef: 'artifact:stdout', contentHash: 'sha256:stdout' },
+    ]);
+    const writer = new ExecutionResultCache({
+      store,
+      hasher,
+      artifactVerifier: { verify: async () => true },
+    });
+    expect(await writer.write({ ...input, projection })).toBe(true);
+
+    const unverified = new ExecutionResultCache({ store, hasher });
+    await expect(unverified.lookup(input)).resolves.toMatchObject({
+      hit: false,
+      reason: 'artifact_verification_unavailable',
+    });
+    const rejected = new ExecutionResultCache({
+      store,
+      hasher,
+      artifactVerifier: { verify: async () => false },
+    });
+    await expect(rejected.lookup(input)).resolves.toMatchObject({
+      hit: false,
+      reason: 'artifact_verification_failed',
+    });
+    expect(store.records.size).toBe(0);
+  });
+
+  it('bounds Store waits and preserves strict-mode diagnostics', async () => {
+    const hangingStore: ExecutionCacheStore = {
+      get: async () => new Promise<ExecutionCacheRecord | null>(() => undefined),
+      set: async () => new Promise<void>(() => undefined),
+      delete: async () => undefined,
+    };
+    const bypass = new ExecutionResultCache({
+      store: hangingStore,
+      hasher,
+      operationTimeoutMs: 5,
+    });
+    await expect(bypass.lookup(cacheInput())).resolves.toMatchObject({
+      hit: false,
+      reason: 'store_unavailable',
+    });
+
+    const strict = new ExecutionResultCache({
+      store: hangingStore,
+      hasher,
+      operationTimeoutMs: 5,
+      failureMode: 'strict',
+    });
+    await expect(strict.lookup(cacheInput())).rejects.toThrow(/exceeded 5ms/u);
+  });
 });
+
+const hasher: ExecutionFingerprintHasher = {
+  algorithm: 'sha256',
+  async hashUtf8(value) {
+    return `sha256:${createHash('sha256').update(value).digest('hex')}`;
+  },
+};
+
+function cacheInput() {
+  return {
+    scope: { userId: 'owner', workspaceId: 'workspace_01' },
+    command: executionCommandFingerprintInputExample,
+    validity: executionCacheValidityInputExample,
+    sideEffectLevel: 'read' as const,
+    environmentFingerprintStatus: 'resolved' as const,
+  };
+}
+
+async function projectionFor(
+  command: typeof executionCommandFingerprintInputExample,
+  validity: typeof executionCacheValidityInputExample,
+  artifacts = executionCacheEntryProjectionExample.artifacts.slice(0, 0)
+) {
+  return {
+    ...executionCacheEntryProjectionExample,
+    commandHash: await hasher.hashUtf8(canonicalizeExecutionFingerprintInput(command)),
+    validityHash: await hasher.hashUtf8(canonicalizeExecutionFingerprintInput(validity)),
+    validity,
+    artifacts,
+    resultMetadata: {
+      ...executionCacheEntryProjectionExample.resultMetadata,
+      status: 'completed' as const,
+    },
+  };
+}
+
+class TestExecutionCacheStore implements ExecutionCacheStore {
+  readonly records = new Map<string, ExecutionCacheRecord>();
+
+  async get(key: string): Promise<ExecutionCacheRecord | null> {
+    return this.records.get(key) ?? null;
+  }
+
+  async set(key: string, record: ExecutionCacheRecord): Promise<void> {
+    this.records.set(key, record);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.records.delete(key);
+  }
+}

--- a/packages/core/src/modules/execution-cache/index.ts
+++ b/packages/core/src/modules/execution-cache/index.ts
@@ -3,6 +3,8 @@ import type {
   ExecutionCacheArtifactReference,
   ExecutionCacheEntryProjection,
   ExecutionCacheResultMetadata,
+  ExecutionCacheRecord,
+  ExecutionCacheScope,
   ExecutionCacheReuseAssessment,
   ExecutionCacheReuseAssessmentInput,
   ExecutionCacheValidityInput,
@@ -162,6 +164,36 @@ export const executionCacheEntryProjectionSchema = z
     }
   }) satisfies ZodType<ExecutionCacheEntryProjection>;
 
+export const executionCacheScopeSchema = z
+  .object({
+    tenantId: nonEmptyString.optional(),
+    userId: nonEmptyString,
+    workspaceId: nonEmptyString,
+  })
+  .strict() satisfies ZodType<ExecutionCacheScope>;
+
+export const executionCacheRecordSchema = z
+  .object({
+    schemaVersion: z.literal('1.0'),
+    keyVersion: z.literal('1'),
+    key: nonEmptyString,
+    scope: executionCacheScopeSchema,
+    projection: executionCacheEntryProjectionSchema,
+    createdAt: z.number().int().nonnegative(),
+    expiresAt: z.number().int().nonnegative().optional(),
+    sizeBytes: z.number().int().nonnegative().optional(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.expiresAt !== undefined && value.expiresAt <= value.createdAt) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['expiresAt'],
+        message: 'must be later than createdAt',
+      });
+    }
+  }) satisfies ZodType<ExecutionCacheRecord>;
+
 const hashJsonSchema: JsonSchema = {
   type: 'string',
   minLength: 1,
@@ -297,6 +329,33 @@ export const executionCacheEntryProjectionJsonSchema: JsonSchema = {
   additionalProperties: false,
 };
 
+export const executionCacheScopeJsonSchema: JsonSchema = {
+  type: 'object',
+  required: ['userId', 'workspaceId'],
+  properties: {
+    tenantId: nonEmptyStringJsonSchema,
+    userId: nonEmptyStringJsonSchema,
+    workspaceId: nonEmptyStringJsonSchema,
+  },
+  additionalProperties: false,
+};
+
+export const executionCacheRecordJsonSchema: JsonSchema = {
+  type: 'object',
+  required: ['schemaVersion', 'keyVersion', 'key', 'scope', 'projection', 'createdAt'],
+  properties: {
+    schemaVersion: { const: '1.0' },
+    keyVersion: { const: '1' },
+    key: nonEmptyStringJsonSchema,
+    scope: executionCacheScopeJsonSchema,
+    projection: executionCacheEntryProjectionJsonSchema,
+    createdAt: { type: 'integer', minimum: 0 },
+    expiresAt: { type: 'integer', minimum: 0 },
+    sizeBytes: { type: 'integer', minimum: 0 },
+  },
+  additionalProperties: false,
+};
+
 export const executionEnvironmentFingerprintResolutionJsonSchema: JsonSchema = {
   oneOf: [
     {
@@ -328,6 +387,8 @@ export const executionCacheJsonSchemas: Record<string, JsonSchema> = {
   ExecutionCacheArtifactReference: executionCacheArtifactReferenceJsonSchema,
   ExecutionCacheResultMetadata: executionCacheResultMetadataJsonSchema,
   ExecutionCacheEntryProjection: executionCacheEntryProjectionJsonSchema,
+  ExecutionCacheScope: executionCacheScopeJsonSchema,
+  ExecutionCacheRecord: executionCacheRecordJsonSchema,
 };
 
 export const executionCacheValidityInputExample: ExecutionCacheValidityInput = {
@@ -420,6 +481,14 @@ export function validateExecutionCacheEntryProjection(
   return executionCacheEntryProjectionSchema.parse(input);
 }
 
+export function validateExecutionCacheScope(input: unknown): ExecutionCacheScope {
+  return executionCacheScopeSchema.parse(input);
+}
+
+export function validateExecutionCacheRecord(input: unknown): ExecutionCacheRecord {
+  return executionCacheRecordSchema.parse(input);
+}
+
 export function canonicalizeExecutionFingerprintInput(
   input: ExecutionCommandFingerprintInput | ExecutionCacheValidityInput
 ): string {
@@ -443,6 +512,9 @@ export function assessExecutionCacheReuse(
   if (parsed.environmentFingerprintStatus === 'unavailable') {
     return { reusable: false, reason: 'environment_fingerprint_unavailable' };
   }
+  if (parsed.sideEffectLevel === 'write') {
+    return { reusable: false, reason: 'workspace_write' };
+  }
   if (parsed.sideEffectLevel === 'external_effect') {
     return { reusable: false, reason: 'external_side_effect' };
   }
@@ -465,3 +537,5 @@ function canonicalizeJsonValue(value: unknown): unknown {
   }
   return value;
 }
+
+export * from './runtime';

--- a/packages/core/src/modules/execution-cache/runtime.ts
+++ b/packages/core/src/modules/execution-cache/runtime.ts
@@ -1,0 +1,343 @@
+import type {
+  ExecutionCacheArtifactVerifier,
+  ExecutionCacheEvent,
+  ExecutionCacheFailureMode,
+  ExecutionCacheLookupInput,
+  ExecutionCacheLookupResult,
+  ExecutionCacheMissReason,
+  ExecutionCacheRecord,
+  ExecutionCacheScope,
+  ExecutionCacheStore,
+  ExecutionCacheWriteInput,
+  ExecutionFingerprintHasher,
+} from '../../contracts/execution-cache';
+import {
+  assessExecutionCacheReuse,
+  canonicalizeExecutionFingerprintInput,
+  validateExecutionCacheEntryProjection,
+  validateExecutionCacheRecord,
+  validateExecutionCacheScope,
+  validateExecutionCacheValidityInput,
+  validateExecutionCommandFingerprintInput,
+} from './index';
+
+export interface ExecutionResultCacheOptions {
+  store: ExecutionCacheStore;
+  hasher: ExecutionFingerprintHasher;
+  artifactVerifier?: ExecutionCacheArtifactVerifier;
+  failureMode?: ExecutionCacheFailureMode;
+  operationTimeoutMs?: number;
+  ttlMs?: number;
+  maxEntryBytes?: number;
+  now?: () => number;
+  trace?: (event: ExecutionCacheEvent) => Promise<void> | void;
+}
+
+interface ExecutionCacheIdentity {
+  key: string;
+  commandHash: string;
+  validityHash: string;
+}
+
+/**
+ * Conservative Result Cache for deterministic, read-only command executions.
+ * It returns an Execution-owned projection and never fabricates a new receipt,
+ * mutates a Workspace, or treats a hit as an executed side effect.
+ */
+export class ExecutionResultCache {
+  private readonly failureMode: ExecutionCacheFailureMode;
+  private readonly operationTimeoutMs: number;
+  private readonly ttlMs: number;
+  private readonly maxEntryBytes: number;
+  private readonly now: () => number;
+
+  constructor(private readonly options: ExecutionResultCacheOptions) {
+    this.failureMode = options.failureMode ?? 'bypass';
+    this.operationTimeoutMs = positiveInteger(
+      options.operationTimeoutMs ?? 500,
+      'operationTimeoutMs'
+    );
+    this.ttlMs = positiveInteger(options.ttlMs ?? 1000 * 60 * 60 * 6, 'ttlMs');
+    this.maxEntryBytes = positiveInteger(options.maxEntryBytes ?? 1024 * 1024, 'maxEntryBytes');
+    this.now = options.now ?? Date.now;
+  }
+
+  async lookup(rawInput: ExecutionCacheLookupInput): Promise<ExecutionCacheLookupResult> {
+    let scope: ExecutionCacheScope;
+    try {
+      scope = validateExecutionCacheScope(rawInput.scope);
+      const input = validateLookupInput(rawInput, scope);
+      const blocked = reuseBlockReason(input);
+      if (blocked) return this.miss(scope, blocked, undefined, 'execution.cache.bypass');
+
+      const identity = await this.identity(input);
+      await this.emit({ type: 'execution.cache.lookup', key: identity.key, scope });
+      const rawRecord = await this.storeOperation('get', this.options.store.get(identity.key));
+      if (!rawRecord) return this.miss(scope, 'not_found', identity.key);
+
+      let record: ExecutionCacheRecord;
+      try {
+        record = validateExecutionCacheRecord(rawRecord);
+      } catch {
+        await this.safeDelete(identity.key);
+        return this.miss(scope, 'corrupt', identity.key, 'execution.cache.invalidate');
+      }
+      if (record.key !== identity.key) {
+        await this.safeDelete(identity.key);
+        return this.miss(scope, 'key_mismatch', identity.key, 'execution.cache.invalidate');
+      }
+      if (!sameScope(record.scope, scope)) {
+        await this.safeDelete(identity.key);
+        return this.miss(scope, 'scope_mismatch', identity.key, 'execution.cache.invalidate');
+      }
+      if (record.expiresAt !== undefined && record.expiresAt <= this.now()) {
+        await this.safeDelete(identity.key);
+        return this.miss(scope, 'expired', identity.key, 'execution.cache.invalidate');
+      }
+      if (
+        record.projection.commandHash !== identity.commandHash ||
+        record.projection.validityHash !== identity.validityHash
+      ) {
+        await this.safeDelete(identity.key);
+        return this.miss(scope, 'validity_changed', identity.key, 'execution.cache.invalidate');
+      }
+      if (record.projection.resultMetadata.status !== 'completed') {
+        await this.safeDelete(identity.key);
+        return this.miss(scope, 'not_cacheable_status', identity.key, 'execution.cache.invalidate');
+      }
+      if (record.projection.artifacts.length > 0 && !this.options.artifactVerifier) {
+        return this.miss(scope, 'artifact_verification_unavailable', identity.key);
+      }
+      if (
+        this.options.artifactVerifier &&
+        !(await this.storeOperation(
+          'verifyArtifacts',
+          this.options.artifactVerifier.verify(scope, record.projection.artifacts)
+        ))
+      ) {
+        await this.safeDelete(identity.key);
+        return this.miss(
+          scope,
+          'artifact_verification_failed',
+          identity.key,
+          'execution.cache.invalidate'
+        );
+      }
+
+      const ageMs = Math.max(0, this.now() - record.createdAt);
+      await this.emit({ type: 'execution.cache.hit', key: identity.key, scope, ageMs });
+      return {
+        hit: true,
+        key: identity.key,
+        projection: clone(record.projection),
+        ageMs,
+      };
+    } catch (error) {
+      if (this.failureMode === 'strict') throw error;
+      const fallbackScope = safeScope(rawInput.scope);
+      return this.miss(fallbackScope, 'store_unavailable', undefined, 'execution.cache.bypass');
+    }
+  }
+
+  async write(rawInput: ExecutionCacheWriteInput): Promise<boolean> {
+    let scope: ExecutionCacheScope;
+    try {
+      scope = validateExecutionCacheScope(rawInput.scope);
+      const input = validateLookupInput(rawInput, scope);
+      const blocked = reuseBlockReason(input);
+      if (blocked) {
+        await this.miss(scope, blocked, undefined, 'execution.cache.bypass');
+        return false;
+      }
+      const projection = validateExecutionCacheEntryProjection(rawInput.projection);
+      if (projection.resultMetadata.status !== 'completed') {
+        await this.miss(scope, 'not_cacheable_status', undefined, 'execution.cache.bypass');
+        return false;
+      }
+      const identity = await this.identity(input);
+      if (
+        projection.commandHash !== identity.commandHash ||
+        projection.validityHash !== identity.validityHash
+      ) {
+        await this.miss(scope, 'validity_changed', identity.key, 'execution.cache.bypass');
+        return false;
+      }
+      const createdAt = this.now();
+      const record: ExecutionCacheRecord = {
+        schemaVersion: '1.0',
+        keyVersion: '1',
+        key: identity.key,
+        scope,
+        projection,
+        createdAt,
+        expiresAt: createdAt + positiveInteger(rawInput.ttlMs ?? this.ttlMs, 'ttlMs'),
+      };
+      const serialized = JSON.stringify(record);
+      const sizeBytes = Buffer.byteLength(serialized, 'utf8');
+      if (sizeBytes > this.maxEntryBytes) {
+        await this.miss(scope, 'entry_oversized', identity.key, 'execution.cache.bypass');
+        return false;
+      }
+      const persisted = validateExecutionCacheRecord({ ...record, sizeBytes });
+      await this.storeOperation('set', this.options.store.set(identity.key, persisted));
+      await this.emit({ type: 'execution.cache.write', key: identity.key, scope });
+      return true;
+    } catch (error) {
+      if (this.failureMode === 'strict') throw error;
+      await this.miss(
+        safeScope(rawInput.scope),
+        'store_unavailable',
+        undefined,
+        'execution.cache.bypass'
+      );
+      return false;
+    }
+  }
+
+  async invalidate(rawInput: ExecutionCacheLookupInput): Promise<boolean> {
+    try {
+      const scope = validateExecutionCacheScope(rawInput.scope);
+      const input = validateLookupInput(rawInput, scope);
+      const identity = await this.identity(input);
+      await this.storeOperation('delete', this.options.store.delete(identity.key));
+      await this.emit({ type: 'execution.cache.invalidate', key: identity.key, scope });
+      return true;
+    } catch (error) {
+      if (this.failureMode === 'strict') throw error;
+      await this.miss(
+        safeScope(rawInput.scope),
+        'store_unavailable',
+        undefined,
+        'execution.cache.bypass'
+      );
+      return false;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (!this.options.store.close) return;
+    try {
+      await this.storeOperation('close', this.options.store.close());
+    } catch (error) {
+      if (this.failureMode === 'strict') throw error;
+    }
+  }
+
+  private async identity(input: ExecutionCacheLookupInput): Promise<ExecutionCacheIdentity> {
+    const [commandHash, validityHash] = await Promise.all([
+      this.options.hasher.hashUtf8(canonicalizeExecutionFingerprintInput(input.command)),
+      this.options.hasher.hashUtf8(canonicalizeExecutionFingerprintInput(input.validity)),
+    ]);
+    const keyHash = await this.options.hasher.hashUtf8(
+      JSON.stringify({
+        schemaVersion: '1',
+        scope: orderedScope(input.scope),
+        commandHash,
+      })
+    );
+    return { key: `execution-cache:v1:${keyHash}`, commandHash, validityHash };
+  }
+
+  private async safeDelete(key: string): Promise<void> {
+    try {
+      await this.storeOperation('delete', this.options.store.delete(key));
+    } catch (error) {
+      if (this.failureMode === 'strict') throw error;
+    }
+  }
+
+  private async storeOperation<T>(operation: string, promise: Promise<T>): Promise<T> {
+    return withTimeout(promise, this.operationTimeoutMs, operation);
+  }
+
+  private async miss(
+    scope: ExecutionCacheScope,
+    reason: ExecutionCacheMissReason,
+    key?: string,
+    type: ExecutionCacheEvent['type'] = 'execution.cache.miss'
+  ): Promise<ExecutionCacheLookupResult> {
+    await this.emit({ type, key, scope, reason });
+    return { hit: false, reason, ...(key ? { key } : {}) };
+  }
+
+  private async emit(event: ExecutionCacheEvent): Promise<void> {
+    try {
+      await this.options.trace?.(event);
+    } catch {
+      // Cache observability is optional and cannot change Execution behavior.
+    }
+  }
+}
+
+function validateLookupInput(
+  input: ExecutionCacheLookupInput,
+  scope: ExecutionCacheScope
+): ExecutionCacheLookupInput {
+  return {
+    scope,
+    command: validateExecutionCommandFingerprintInput(input.command),
+    validity: validateExecutionCacheValidityInput(input.validity),
+    sideEffectLevel: input.sideEffectLevel,
+    environmentFingerprintStatus: input.environmentFingerprintStatus,
+  };
+}
+
+function reuseBlockReason(input: ExecutionCacheLookupInput): ExecutionCacheMissReason | null {
+  const assessment = assessExecutionCacheReuse({
+    sideEffectLevel: input.sideEffectLevel,
+    environmentFingerprintStatus: input.environmentFingerprintStatus,
+  });
+  return assessment.reusable ? null : assessment.reason;
+}
+
+function sameScope(left: ExecutionCacheScope, right: ExecutionCacheScope): boolean {
+  return JSON.stringify(orderedScope(left)) === JSON.stringify(orderedScope(right));
+}
+
+function orderedScope(scope: ExecutionCacheScope): Record<string, string | undefined> {
+  return {
+    tenantId: scope.tenantId,
+    userId: scope.userId,
+    workspaceId: scope.workspaceId,
+  };
+}
+
+function safeScope(value: unknown): ExecutionCacheScope {
+  try {
+    return validateExecutionCacheScope(value);
+  } catch {
+    return { userId: 'invalid-scope', workspaceId: 'invalid-scope' };
+  }
+}
+
+function positiveInteger(value: number, field: string): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new TypeError(`${field} must be a positive integer.`);
+  }
+  return value;
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  operation: string
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`Execution Cache ${operation} exceeded ${timeoutMs}ms.`)),
+          timeoutMs
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}


### PR DESCRIPTION
## Summary
- add versioned, user/workspace-scoped Execution Cache records and strict schemas
- add a conservative Result Cache manager with validity hashes, timeouts, fail-open/strict modes, size limits, trace events, and Artifact verification
- block Workspace writes, external/irreversible effects, unstable environments, and non-completed results
- add a bounded local Store and SHA-256 hasher adapter

A cache hit is only a reusable projection; it never fabricates an execution receipt or replays a Workspace side effect.

## Validation
- npm run lint
- npm run typecheck
- npm run build
- npm run test:unit (65)
- npm run test:packages (1040)
- focused Execution Cache tests (13)