### PR TITLE
fix(runtime/inference): canonical-json crash, missing tool schemas, MCP capability scope

### DIFF
--- a/apps/server/src/services/EventRuntime.ts
+++ b/apps/server/src/services/EventRuntime.ts
@@ -907,6 +907,8 @@ class EventRuntimeService {
     const contractSnapshotRef =
       request.context.contractSnapshotRef ??
       (await this.ensureRunToolSnapshot(request.context.runId));
+    const contractSnapshot = await this.toolSnapshotStore.get(contractSnapshotRef);
+    const effectiveCapabilities = contractSnapshot?.effectiveCapabilities;
     return this.toolRunner.run({
       ...request,
       toolId,
@@ -915,6 +917,9 @@ class EventRuntimeService {
         userId,
         sessionId,
         contractSnapshotRef,
+        ...(effectiveCapabilities === undefined
+          ? {}
+          : { capabilitySnapshotRef: contractSnapshotRef }),
         principal: request.context.principal ?? {
           id: userId,
           principalId: userId,
@@ -1931,14 +1936,28 @@ class EventRuntimeService {
       : [];
     const availableToolIds = spec.toolRefs ?? input.options?.tools?.map((tool) => tool.name) ?? [];
     const capabilityMetadata = asRecord(spec.metadata);
+    const allowedMCPServerIds = Array.from(
+      new Set(
+        availableToolIds
+          .map((toolRef) => {
+            const descriptor = getToolManager().describeTool(toolRef);
+            return descriptor?.serverId ?? descriptor?.capabilityId?.split('.')[0];
+          })
+          .filter((serverId): serverId is string => Boolean(serverId)),
+      ),
+    );
     const effectiveCapabilities = createEffectiveAgentCapabilitySnapshot({
       runId: input.runId,
       agentId: id,
       principalId: userId,
       tenantId: stringValue(asRecord(input.metadata)?.tenantId),
       domainId: runContext.domainPackId,
-      agent: capabilityConstraint(capabilityMetadata, availableToolIds, 'agent.policy'),
-      domain: capabilityConstraint(workflowState, availableToolIds, 'domain.policy'),
+      agent: capabilityConstraint(capabilityMetadata, availableToolIds, 'agent.policy', {
+        allowedMCPServerIds,
+      }),
+      domain: capabilityConstraint(workflowState, availableToolIds, 'domain.policy', {
+        allowedMCPServerIds,
+      }),
       activeSkills,
     });
     this.runCapabilitySnapshots.set(input.runId, effectiveCapabilities);
@@ -4892,7 +4911,8 @@ function stringList(input: unknown): string[] | undefined {
 function capabilityConstraint(
   source: Record<string, unknown> | undefined,
   fallbackToolIds: string[],
-  defaultPolicyRef: string
+  defaultPolicyRef: string,
+  extras: { allowedMCPServerIds?: string[] } = {},
 ): EffectiveAgentCapabilitySnapshotInput['agent'] {
   const memory = stringValue(source?.memoryAccess);
   const sideEffect = stringValue(source?.maximumSideEffectLevel);
@@ -4911,7 +4931,10 @@ function capabilityConstraint(
   return {
     allowedToolIds:
       stringList(source?.allowedToolIds) ?? stringList(source?.allowedTools) ?? fallbackToolIds,
-    allowedMCPServerIds: stringList(source?.allowedMCPServerIds),
+    allowedMCPServerIds:
+      stringList(source?.allowedMCPServerIds)?.length
+        ? (stringList(source?.allowedMCPServerIds) as string[])
+        : extras.allowedMCPServerIds ?? [],
     memoryAccess,
     allowedExecutionProfiles: stringList(source?.allowedExecutionProfiles) ?? [],
     maximumSideEffectLevel,

--- a/apps/server/src/services/EventRuntime.ts
+++ b/apps/server/src/services/EventRuntime.ts
@@ -72,6 +72,7 @@ import {
   type InferenceProvider,
   type InferenceRequest,
   type InferenceResponse,
+  type InferenceToolDescriptor,
   type LocalInferenceDriver,
   type KvCacheRef,
   type KvCacheScope,
@@ -778,12 +779,26 @@ class EventRuntimeService {
   private createCanonicalReActAgentRuntime(): ReActAgentRuntime {
     return {
       async reason(context) {
+        const toolRefs = context.agent.toolRefs ?? [];
+        const tools: InferenceToolDescriptor[] = toolRefs
+          .map((toolRef) => {
+            const descriptor = getToolManager().describeTool(toolRef);
+            if (!descriptor) return null;
+            return {
+              id: descriptor.id ?? toolRef,
+              name: descriptor.name ?? toolRef,
+              description: descriptor.description ?? toolRef,
+              inputSchema: descriptor.inputSchema as Record<string, unknown>,
+            } as InferenceToolDescriptor;
+          })
+          .filter((tool): tool is InferenceToolDescriptor => tool !== null);
         return {
           runId: context.runId,
           stepId: context.stepId,
           sessionId: context.memoryScope?.sessionId,
           agentId: context.agent.id,
           modelAlias: context.agent.modelAlias,
+          ...(tools.length === 0 ? {} : { tools }),
           input: {
             instructions: context.agent.systemInstructions,
             messages: context.messages,

--- a/apps/server/src/services/EventRuntime.ts
+++ b/apps/server/src/services/EventRuntime.ts
@@ -1954,9 +1954,11 @@ class EventRuntimeService {
         input.options?.model ??
         this.resolveChatModel().model,
       systemInstructions,
-      promptResolution,
+      ...(promptResolution === undefined ? {} : { promptResolution }),
       activeSkills,
-      toolRefs: spec.toolRefs ?? input.options?.tools?.map((tool) => tool.name),
+      ...(spec.toolRefs ?? input.options?.tools?.map((tool) => tool.name)
+        ? { toolRefs: spec.toolRefs ?? input.options?.tools?.map((tool) => tool.name) }
+        : {}),
     };
   }
 

--- a/packages/inference/src/agent-prompts.ts
+++ b/packages/inference/src/agent-prompts.ts
@@ -243,10 +243,10 @@ export class AgentPromptRegistry {
         templateContentHash: spec.contentHash!,
         scope: spec.scope ?? 'global',
         trustLevel: spec.trustLevel ?? 'reviewed',
-        ownerId: spec.ownerId,
-        tenantId: spec.tenantId,
-        provenance: spec.provenance,
-        metadata: spec.metadata,
+        ...(spec.ownerId === undefined ? {} : { ownerId: spec.ownerId }),
+        ...(spec.tenantId === undefined ? {} : { tenantId: spec.tenantId }),
+        ...(spec.provenance === undefined ? {} : { provenance: spec.provenance }),
+        ...(spec.metadata === undefined ? {} : { metadata: spec.metadata }),
       });
     }
     return {


### PR DESCRIPTION
## Summary

Three framework-level defects found while integrating Hypha as the agent runtime. All three are verified fixed locally (typecheck passes, fixes validated in a running deployment).

### 1. fix(inference): canonicalizeJson crash on undefined optional prompt block fields

`ResolvedAgentPromptBlock` optional fields (`ownerId` / `tenantId` / `provenance` / `metadata`) were assigned directly even when `undefined`. `canonicalizeJson` rejects `undefined` values with `RUNTIME_INVALID_INPUT`, so **any ReAct run whose prompt block omits the optional fields fails at startup** with `RUNTIME_INVALID_INPUT`.

Fix: conditionally spread the fields only when defined. The same crash class existed in `resolveChatAgent` (`promptResolution` / `toolRefs`) and is guarded the same way.

### 2. fix(runtime): ReAct reasoning never receives tool schemas

`createCanonicalReActAgentRuntime.reason()` returned an `InferenceRequest` **without the `tools` field**. The model receives no tool definitions, so it fabricates JSON tool calls as plain text that are never executed — tool use silently does nothing.

Fix: resolve each `context.agent.toolRefs` entry via `ToolManager.describeTool` and attach the descriptors to the request.

### 3. fix(runtime): MCP tools rejected by TOOL_CAPABILITY_SCOPE_DENIED

`createEffectiveAgentCapabilitySnapshot` runs `capabilityConstraint` for agent and domain scopes, both defaulting `allowedMCPServerIds` to empty. With the config's default allowlist empty, **every MCP-backed tool is rejected with `TOOL_CAPABILITY_SCOPE_DENIED`** even though the tool is explicitly referenced by the agent.

Fix: derive the MCP server ids from the agent's `toolRefs` (via `ToolManager.describeTool` `serverId` / `capabilityId`) and pass them into both constraints; also forward the effective capability snapshot ref to the tool runner when available.

## Verification

- `npm run typecheck` passes on the branch
- All three fixes validated in a live deployment (canonical-json crash gone, ReAct tool calls executed, MCP tools usable)

## Notes

- Base branch `dev` per CONTRIBUTING.md (Framework source fixes integrate via `dev`)
- Local-only `config.yaml` additions (environment-specific MCP servers) intentionally excluded
