### PR TITLE
fix(ci): resolve npm audit findings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
       ],
       "dependencies": {
         "@anthropic-ai/sdk": "^0.20.0",
-        "@google/generative-ai": "^0.2.0",
         "@codesoul-co/hypha-workcache": "0.0.0",
+        "@google/generative-ai": "^0.2.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
@@ -634,6 +634,78 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@codesoul-co/hypha-adapters-local": {
+      "resolved": "packages/adapters-local",
+      "link": true
+    },
+    "node_modules/@codesoul-co/hypha-cli": {
+      "resolved": "apps/cli",
+      "link": true
+    },
+    "node_modules/@codesoul-co/hypha-core": {
+      "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@codesoul-co/hypha-domain": {
+      "resolved": "packages/domain",
+      "link": true
+    },
+    "node_modules/@codesoul-co/hypha-fsm": {
+      "resolved": "packages/fsm",
+      "link": true
+    },
+    "node_modules/@codesoul-co/hypha-harness": {
+      "resolved": "packages/harness",
+      "link": true
+    },
+    "node_modules/@codesoul-co/hypha-inference": {
+      "resolved": "packages/inference",
+      "link": true
+    },
+    "node_modules/@codesoul-co/hypha-kernel": {
+      "resolved": "packages/kernel",
+      "link": true
+    },
+    "node_modules/@codesoul-co/hypha-mcp": {
+      "resolved": "packages/mcp",
+      "link": true
+    },
+    "node_modules/@codesoul-co/hypha-memory": {
+      "resolved": "packages/memory",
+      "link": true
+    },
+    "node_modules/@codesoul-co/hypha-models": {
+      "resolved": "packages/models",
+      "link": true
+    },
+    "node_modules/@codesoul-co/hypha-server": {
+      "resolved": "apps/server",
+      "link": true
+    },
+    "node_modules/@codesoul-co/hypha-serving-cache": {
+      "resolved": "packages/serving-cache",
+      "link": true
+    },
+    "node_modules/@codesoul-co/hypha-skills": {
+      "resolved": "packages/skills",
+      "link": true
+    },
+    "node_modules/@codesoul-co/hypha-storage": {
+      "resolved": "packages/storage",
+      "link": true
+    },
+    "node_modules/@codesoul-co/hypha-testing": {
+      "resolved": "packages/testing",
+      "link": true
+    },
+    "node_modules/@codesoul-co/hypha-tools": {
+      "resolved": "packages/tools",
+      "link": true
+    },
+    "node_modules/@codesoul-co/hypha-workcache": {
+      "resolved": "packages/workcache",
+      "link": true
     },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
@@ -1330,78 +1402,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/@codesoul-co/hypha-adapters-local": {
-      "resolved": "packages/adapters-local",
-      "link": true
-    },
-    "node_modules/@codesoul-co/hypha-cli": {
-      "resolved": "apps/cli",
-      "link": true
-    },
-    "node_modules/@codesoul-co/hypha-core": {
-      "resolved": "packages/core",
-      "link": true
-    },
-    "node_modules/@codesoul-co/hypha-domain": {
-      "resolved": "packages/domain",
-      "link": true
-    },
-    "node_modules/@codesoul-co/hypha-fsm": {
-      "resolved": "packages/fsm",
-      "link": true
-    },
-    "node_modules/@codesoul-co/hypha-harness": {
-      "resolved": "packages/harness",
-      "link": true
-    },
-    "node_modules/@codesoul-co/hypha-inference": {
-      "resolved": "packages/inference",
-      "link": true
-    },
-    "node_modules/@codesoul-co/hypha-kernel": {
-      "resolved": "packages/kernel",
-      "link": true
-    },
-    "node_modules/@codesoul-co/hypha-mcp": {
-      "resolved": "packages/mcp",
-      "link": true
-    },
-    "node_modules/@codesoul-co/hypha-memory": {
-      "resolved": "packages/memory",
-      "link": true
-    },
-    "node_modules/@codesoul-co/hypha-models": {
-      "resolved": "packages/models",
-      "link": true
-    },
-    "node_modules/@codesoul-co/hypha-server": {
-      "resolved": "apps/server",
-      "link": true
-    },
-    "node_modules/@codesoul-co/hypha-serving-cache": {
-      "resolved": "packages/serving-cache",
-      "link": true
-    },
-    "node_modules/@codesoul-co/hypha-skills": {
-      "resolved": "packages/skills",
-      "link": true
-    },
-    "node_modules/@codesoul-co/hypha-storage": {
-      "resolved": "packages/storage",
-      "link": true
-    },
-    "node_modules/@codesoul-co/hypha-testing": {
-      "resolved": "packages/testing",
-      "link": true
-    },
-    "node_modules/@codesoul-co/hypha-tools": {
-      "resolved": "packages/tools",
-      "link": true
-    },
-    "node_modules/@codesoul-co/hypha-workcache": {
-      "resolved": "packages/workcache",
-      "link": true
-    },
     "node_modules/@ioredis/commands": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
@@ -1450,9 +1450,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7764,9 +7764,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -8744,9 +8744,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Problem

The `Repository gates` CI job runs `npm audit` and has been failing on every recent main build with 2 high-severity findings:

- `js-yaml` 3.15.0 / 4.3.0 — quadratic CPU consumption in `!!omap` resolution (CVE-2026-59870)
- `nanoid` 3.3.16 — custom generators can loop indefinitely when size is zero

## Change

`npm audit fix` bumps only the lockfile entries:

- js-yaml 3.15.0 → 3.15.1, 4.3.0 → 4.3.1
- nanoid 3.3.16 → 3.3.18

No package.json ranges changed.

## Verification

- `npm audit` → 0 vulnerabilities ✅
- `npm run build:packages` ✅
- `npx vitest run packages/skills/src/skills.test.ts` (12 tests) ✅