### PR TITLE
chore(release): prepare @codesoul-co/hypha-* 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hypha",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hypha",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
@@ -12113,15 +12113,15 @@
     },
     "packages/adapters-local": {
       "name": "@codesoul-co/hypha-adapters-local",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@codesoul-co/hypha-core": "1.0.0",
-        "@codesoul-co/hypha-kernel": "1.0.0",
-        "@codesoul-co/hypha-mcp": "1.0.0",
-        "@codesoul-co/hypha-memory": "1.0.0",
-        "@codesoul-co/hypha-storage": "1.0.0",
-        "@codesoul-co/hypha-tools": "1.0.0",
+        "@codesoul-co/hypha-core": "1.0.1",
+        "@codesoul-co/hypha-kernel": "1.0.1",
+        "@codesoul-co/hypha-mcp": "1.0.1",
+        "@codesoul-co/hypha-memory": "1.0.1",
+        "@codesoul-co/hypha-storage": "1.0.1",
+        "@codesoul-co/hypha-tools": "1.0.1",
         "better-sqlite3": "^11.10.0",
         "minio": "8.0.7",
         "pg": "8.22.0",
@@ -12131,9 +12131,50 @@
         "node": ">=22.0.0"
       }
     },
+    "packages/adapters-local/node_modules/@codesoul-co/hypha-inference": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@codesoul-co/hypha-inference/-/hypha-inference-1.0.0.tgz",
+      "integrity": "sha512-nOZ5f4wHXXqLqkCcHDvXk8Jt24ORxAAaHDc+a+IKWhKHfyPcg0HvQFweUg8w6ia6Vffex0m0aN+u5FgpLaLrAg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@codesoul-co/hypha-core": "1.0.0",
+        "zod": "^3.22.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "packages/adapters-local/node_modules/@codesoul-co/hypha-models": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@codesoul-co/hypha-models/-/hypha-models-1.0.0.tgz",
+      "integrity": "sha512-9V1bm7YyYPy4g2TJMaDc1D/9q/y6xVL4FEj4VRep+614Ml6yqC4ptCedE0Poz4k0M+f/xKBXIRUckIyX6RXckg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@codesoul-co/hypha-core": "1.0.0",
+        "zod": "^3.22.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "packages/adapters-local/node_modules/@codesoul-co/hypha-skills": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@codesoul-co/hypha-skills/-/hypha-skills-1.0.0.tgz",
+      "integrity": "sha512-2DQ8VD7kRcVJ4r6toDT+3ziR0knBYksAEDZszLrRR+yCEZpVQL3OLtTYSG8OzJaQ5C+hLaYoMf/LWjMzN0kUTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@codesoul-co/hypha-core": "1.0.0",
+        "@codesoul-co/hypha-tools": "1.0.0",
+        "yaml": "^2.3.0",
+        "zod": "^3.22.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
     "packages/core": {
       "name": "@codesoul-co/hypha-core",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.20.0",
@@ -12146,15 +12187,15 @@
     },
     "packages/domain": {
       "name": "@codesoul-co/hypha-domain",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@codesoul-co/hypha-core": "1.0.0",
-        "@codesoul-co/hypha-fsm": "1.0.0",
-        "@codesoul-co/hypha-mcp": "1.0.0",
-        "@codesoul-co/hypha-memory": "1.0.0",
-        "@codesoul-co/hypha-skills": "1.0.0",
-        "@codesoul-co/hypha-tools": "1.0.0",
+        "@codesoul-co/hypha-core": "1.0.1",
+        "@codesoul-co/hypha-fsm": "1.0.1",
+        "@codesoul-co/hypha-mcp": "1.0.1",
+        "@codesoul-co/hypha-memory": "1.0.1",
+        "@codesoul-co/hypha-skills": "1.0.1",
+        "@codesoul-co/hypha-tools": "1.0.1",
         "yaml": "^2.3.0",
         "zod": "^3.22.0"
       },
@@ -12164,10 +12205,10 @@
     },
     "packages/fsm": {
       "name": "@codesoul-co/hypha-fsm",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@codesoul-co/hypha-core": "1.0.0",
+        "@codesoul-co/hypha-core": "1.0.1",
         "zod": "^3.22.0"
       },
       "engines": {
@@ -12176,15 +12217,15 @@
     },
     "packages/harness": {
       "name": "@codesoul-co/hypha-harness",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@codesoul-co/hypha-core": "1.0.0",
-        "@codesoul-co/hypha-fsm": "1.0.0",
-        "@codesoul-co/hypha-inference": "1.0.0",
-        "@codesoul-co/hypha-kernel": "1.0.0",
-        "@codesoul-co/hypha-skills": "1.0.0",
-        "@codesoul-co/hypha-tools": "1.0.0"
+        "@codesoul-co/hypha-core": "1.0.1",
+        "@codesoul-co/hypha-fsm": "1.0.1",
+        "@codesoul-co/hypha-inference": "1.0.1",
+        "@codesoul-co/hypha-kernel": "1.0.1",
+        "@codesoul-co/hypha-skills": "1.0.1",
+        "@codesoul-co/hypha-tools": "1.0.1"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -12192,10 +12233,10 @@
     },
     "packages/inference": {
       "name": "@codesoul-co/hypha-inference",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@codesoul-co/hypha-core": "1.0.0",
+        "@codesoul-co/hypha-core": "1.0.1",
         "zod": "^3.22.0"
       },
       "engines": {
@@ -12204,15 +12245,15 @@
     },
     "packages/kernel": {
       "name": "@codesoul-co/hypha-kernel",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@codesoul-co/hypha-core": "1.0.0",
-        "@codesoul-co/hypha-inference": "1.0.0",
-        "@codesoul-co/hypha-memory": "1.0.0",
-        "@codesoul-co/hypha-models": "1.0.0",
-        "@codesoul-co/hypha-skills": "1.0.0",
-        "@codesoul-co/hypha-tools": "1.0.0",
+        "@codesoul-co/hypha-core": "1.0.1",
+        "@codesoul-co/hypha-inference": "1.0.1",
+        "@codesoul-co/hypha-memory": "1.0.1",
+        "@codesoul-co/hypha-models": "1.0.1",
+        "@codesoul-co/hypha-skills": "1.0.1",
+        "@codesoul-co/hypha-tools": "1.0.1",
         "zod": "^3.22.0"
       },
       "engines": {
@@ -12221,11 +12262,11 @@
     },
     "packages/mcp": {
       "name": "@codesoul-co/hypha-mcp",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@codesoul-co/hypha-core": "1.0.0",
-        "@codesoul-co/hypha-tools": "1.0.0",
+        "@codesoul-co/hypha-core": "1.0.1",
+        "@codesoul-co/hypha-tools": "1.0.1",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "zod": "^3.22.0"
       },
@@ -12235,10 +12276,10 @@
     },
     "packages/memory": {
       "name": "@codesoul-co/hypha-memory",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@codesoul-co/hypha-core": "1.0.0",
+        "@codesoul-co/hypha-core": "1.0.1",
         "zod": "^3.22.0"
       },
       "engines": {
@@ -12247,10 +12288,10 @@
     },
     "packages/models": {
       "name": "@codesoul-co/hypha-models",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@codesoul-co/hypha-core": "1.0.0",
+        "@codesoul-co/hypha-core": "1.0.1",
         "zod": "^3.22.0"
       },
       "engines": {
@@ -12259,10 +12300,10 @@
     },
     "packages/serving-cache": {
       "name": "@codesoul-co/hypha-serving-cache",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@codesoul-co/hypha-models": "1.0.0",
+        "@codesoul-co/hypha-models": "1.0.1",
         "better-sqlite3": "^11.10.0",
         "zod": "^3.22.0"
       },
@@ -12272,11 +12313,11 @@
     },
     "packages/skills": {
       "name": "@codesoul-co/hypha-skills",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@codesoul-co/hypha-core": "1.0.0",
-        "@codesoul-co/hypha-tools": "1.0.0",
+        "@codesoul-co/hypha-core": "1.0.1",
+        "@codesoul-co/hypha-tools": "1.0.1",
         "yaml": "^2.3.0",
         "zod": "^3.22.0"
       },
@@ -12286,10 +12327,10 @@
     },
     "packages/storage": {
       "name": "@codesoul-co/hypha-storage",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@codesoul-co/hypha-core": "1.0.0",
+        "@codesoul-co/hypha-core": "1.0.1",
         "zod": "^3.22.0"
       },
       "engines": {
@@ -12298,10 +12339,10 @@
     },
     "packages/testing": {
       "name": "@codesoul-co/hypha-testing",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@codesoul-co/hypha-core": "1.0.0"
+        "@codesoul-co/hypha-core": "1.0.1"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -12309,10 +12350,10 @@
     },
     "packages/tools": {
       "name": "@codesoul-co/hypha-tools",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@codesoul-co/hypha-core": "1.0.0",
+        "@codesoul-co/hypha-core": "1.0.1",
         "ajv": "^8.20.0",
         "zod": "^3.22.0"
       },
@@ -12324,8 +12365,8 @@
       "name": "@codesoul-co/hypha-workcache",
       "version": "0.0.0",
       "dependencies": {
-        "@codesoul-co/hypha-core": "1.0.0",
-        "@codesoul-co/hypha-inference": "1.0.0",
+        "@codesoul-co/hypha-core": "1.0.1",
+        "@codesoul-co/hypha-inference": "1.0.1",
         "better-sqlite3": "^11.10.0",
         "zod": "^3.22.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypha",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "Harness-oriented agent system framework for production-grade LLM agent applications",
   "main": "dist/apps/server/app.js",

--- a/packages/adapters-local/package.json
+++ b/packages/adapters-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesoul-co/hypha-adapters-local",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -26,12 +26,12 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@codesoul-co/hypha-core": "1.0.0",
-    "@codesoul-co/hypha-kernel": "1.0.0",
-    "@codesoul-co/hypha-mcp": "1.0.0",
-    "@codesoul-co/hypha-memory": "1.0.0",
-    "@codesoul-co/hypha-storage": "1.0.0",
-    "@codesoul-co/hypha-tools": "1.0.0",
+    "@codesoul-co/hypha-core": "1.0.1",
+    "@codesoul-co/hypha-kernel": "1.0.1",
+    "@codesoul-co/hypha-mcp": "1.0.1",
+    "@codesoul-co/hypha-memory": "1.0.1",
+    "@codesoul-co/hypha-storage": "1.0.1",
+    "@codesoul-co/hypha-tools": "1.0.1",
     "better-sqlite3": "^11.10.0",
     "minio": "8.0.7",
     "pg": "8.22.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesoul-co/hypha-core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesoul-co/hypha-domain",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,12 +22,12 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@codesoul-co/hypha-core": "1.0.0",
-    "@codesoul-co/hypha-fsm": "1.0.0",
-    "@codesoul-co/hypha-mcp": "1.0.0",
-    "@codesoul-co/hypha-memory": "1.0.0",
-    "@codesoul-co/hypha-skills": "1.0.0",
-    "@codesoul-co/hypha-tools": "1.0.0",
+    "@codesoul-co/hypha-core": "1.0.1",
+    "@codesoul-co/hypha-fsm": "1.0.1",
+    "@codesoul-co/hypha-mcp": "1.0.1",
+    "@codesoul-co/hypha-memory": "1.0.1",
+    "@codesoul-co/hypha-skills": "1.0.1",
+    "@codesoul-co/hypha-tools": "1.0.1",
     "yaml": "^2.3.0",
     "zod": "^3.22.0"
   },

--- a/packages/fsm/package.json
+++ b/packages/fsm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesoul-co/hypha-fsm",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@codesoul-co/hypha-core": "1.0.0",
+    "@codesoul-co/hypha-core": "1.0.1",
     "zod": "^3.22.0"
   },
   "scripts": {

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesoul-co/hypha-harness",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,12 +22,12 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@codesoul-co/hypha-core": "1.0.0",
-    "@codesoul-co/hypha-fsm": "1.0.0",
-    "@codesoul-co/hypha-inference": "1.0.0",
-    "@codesoul-co/hypha-kernel": "1.0.0",
-    "@codesoul-co/hypha-skills": "1.0.0",
-    "@codesoul-co/hypha-tools": "1.0.0"
+    "@codesoul-co/hypha-core": "1.0.1",
+    "@codesoul-co/hypha-fsm": "1.0.1",
+    "@codesoul-co/hypha-inference": "1.0.1",
+    "@codesoul-co/hypha-kernel": "1.0.1",
+    "@codesoul-co/hypha-skills": "1.0.1",
+    "@codesoul-co/hypha-tools": "1.0.1"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/inference/package.json
+++ b/packages/inference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesoul-co/hypha-inference",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@codesoul-co/hypha-core": "1.0.0",
+    "@codesoul-co/hypha-core": "1.0.1",
     "zod": "^3.22.0"
   },
   "scripts": {

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesoul-co/hypha-kernel",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,12 +22,12 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@codesoul-co/hypha-core": "1.0.0",
-    "@codesoul-co/hypha-inference": "1.0.0",
-    "@codesoul-co/hypha-memory": "1.0.0",
-    "@codesoul-co/hypha-models": "1.0.0",
-    "@codesoul-co/hypha-skills": "1.0.0",
-    "@codesoul-co/hypha-tools": "1.0.0",
+    "@codesoul-co/hypha-core": "1.0.1",
+    "@codesoul-co/hypha-inference": "1.0.1",
+    "@codesoul-co/hypha-memory": "1.0.1",
+    "@codesoul-co/hypha-models": "1.0.1",
+    "@codesoul-co/hypha-skills": "1.0.1",
+    "@codesoul-co/hypha-tools": "1.0.1",
     "zod": "^3.22.0"
   },
   "scripts": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesoul-co/hypha-mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,8 +22,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@codesoul-co/hypha-core": "1.0.0",
-    "@codesoul-co/hypha-tools": "1.0.0",
+    "@codesoul-co/hypha-core": "1.0.1",
+    "@codesoul-co/hypha-tools": "1.0.1",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "zod": "^3.22.0"
   },

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesoul-co/hypha-memory",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@codesoul-co/hypha-core": "1.0.0",
+    "@codesoul-co/hypha-core": "1.0.1",
     "zod": "^3.22.0"
   },
   "scripts": {

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesoul-co/hypha-models",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@codesoul-co/hypha-core": "1.0.0",
+    "@codesoul-co/hypha-core": "1.0.1",
     "zod": "^3.22.0"
   },
   "scripts": {

--- a/packages/serving-cache/package.json
+++ b/packages/serving-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesoul-co/hypha-serving-cache",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@codesoul-co/hypha-models": "1.0.0",
+    "@codesoul-co/hypha-models": "1.0.1",
     "better-sqlite3": "^11.10.0",
     "zod": "^3.22.0"
   },

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesoul-co/hypha-skills",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -23,8 +23,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@codesoul-co/hypha-core": "1.0.0",
-    "@codesoul-co/hypha-tools": "1.0.0",
+    "@codesoul-co/hypha-core": "1.0.1",
+    "@codesoul-co/hypha-tools": "1.0.1",
     "yaml": "^2.3.0",
     "zod": "^3.22.0"
   },

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesoul-co/hypha-storage",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@codesoul-co/hypha-core": "1.0.0",
+    "@codesoul-co/hypha-core": "1.0.1",
     "zod": "^3.22.0"
   },
   "scripts": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesoul-co/hypha-testing",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@codesoul-co/hypha-core": "1.0.0"
+    "@codesoul-co/hypha-core": "1.0.1"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesoul-co/hypha-tools",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@codesoul-co/hypha-core": "1.0.0",
+    "@codesoul-co/hypha-core": "1.0.1",
     "ajv": "^8.20.0",
     "zod": "^3.22.0"
   },

--- a/packages/workcache/package.json
+++ b/packages/workcache/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@codesoul-co/hypha-core": "1.0.0",
-    "@codesoul-co/hypha-inference": "1.0.0",
+    "@codesoul-co/hypha-core": "1.0.1",
+    "@codesoul-co/hypha-inference": "1.0.1",
     "better-sqlite3": "^11.10.0",
     "zod": "^3.22.0"
   },


### PR DESCRIPTION
## Why

The published 1.0.0 line was cut before two mainline fixes:

- **#22** — `@codesoul-co/hypha-skills` now ships `builtins/` in its tarball and exports `resolveBuiltinSkillsDirectory()`; npm consumers could not load the framework built-in skills from the 1.0.0 tarball.
- **#23** — npm audit findings (js-yaml, nanoid) that make the Repository gates job fail.

## Change

- Bump the root and all 15 publishable packages to 1.0.1.
- Align every internal `@codesoul-co/hypha-*` dependency on the exact 1.0.1 version.

## Verification

- `npm run build:packages` ✅
- `npm run release:check:npm` → 15 publishable packages at 1.0.1 ✅
- skills package tests (14) ✅